### PR TITLE
break up the gigantic loops; a few misc fixes

### DIFF
--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -11,6 +11,8 @@ services:
        - 6379:6379
        - 6799:6799
     working_dir: /acorn/server
+    environment:
+      - PYTHONPATH=/acorn/vehicle
     volumes:
       - .:/acorn
       - /etc/localtime:/etc/localtime:ro

--- a/docker-compose-simulation.yml
+++ b/docker-compose-simulation.yml
@@ -28,6 +28,8 @@ services:
        - 6379:6379
        - 6799:6799
     working_dir: /acorn/server
+    environment:
+      - PYTHONPATH=/acorn/vehicle
     volumes:
       - .:/acorn
       - /etc/localtime:/etc/localtime:ro

--- a/kill-docker.sh
+++ b/kill-docker.sh
@@ -1,2 +1,4 @@
 docker kill acorn_server
 docker rm acorn_server
+docker kill acorn_vehicle
+docker rm acorn_vehicle

--- a/server/autolaunch_server.sh
+++ b/server/autolaunch_server.sh
@@ -1,6 +1,5 @@
 echo $PWD
 tmux new-session -d -s "redis" sh redis-command.sh&
-tmux new-session -d -s "redis-silo" sh redis-silo-command.sh&
 tmux new-session -d -s "zmq" python3 zmq_server_pirate.py&
 tmux new-session -d -s "zmq_ppq" python3 zmq_ppqueue.py&
 tmux new-session -d -s "web" python3 server.py&

--- a/server/local_datalog.py
+++ b/server/local_datalog.py
@@ -26,16 +26,11 @@ limitations under the License.
 while True:
     try:
         import time
-        from flask import Flask, render_template, request, send_from_directory, jsonify
+        from flask import Flask, jsonify
         from flask_redis import FlaskRedis
-        import sys
-        from svgpathtools import svg2paths, paths2svg
-        import re
         import pickle
         import json
         import datetime
-        sys.path.append('../vehicle')
-        from master_process import Robot, RobotCommand
         break
     except Exception as e:
         print(e)
@@ -52,11 +47,8 @@ volatile_path = []  # When the robot is streaming a path, save it in RAM here.
 active_site = "twistedfields"
 
 
-def date_handler(obj): return (
-    obj.isoformat() + "-07:00"
-    if isinstance(obj, (datetime.datetime, datetime.date))
-    else None
-)
+def date_handler(obj):
+    return obj.isoformat() + "-07:00" if isinstance(obj, (datetime.datetime, datetime.date)) else None
 
 
 def send_herd_data():
@@ -78,7 +70,7 @@ def load_first_robot(redis_client):
     keys = get_robot_keys()
     for key in keys:
         robot = pickle.loads(redis_client.get(key))
-        time_stamp = json.dumps(robot.time_stamp, default=date_handler)
+        # time_stamp = json.dumps(robot.time_stamp, default=date_handler)
         return robot
 
 
@@ -96,7 +88,8 @@ def robots_to_json(keys):
                        'speed': robot.speed, 'turn_intent_degrees': robot.turn_intent_degrees,
                        'voltage': robot.voltage, 'control_state': robot.control_state,
                        'motor_state': robot.motor_state, 'time_stamp': time_stamp,
-                       'loaded_path_name': "" if not robot.loaded_path_name else robot.loaded_path_name.split('gpspath:')[1].split(':key')[0],
+                       'loaded_path_name': ("" if not robot.loaded_path_name
+                                            else robot.loaded_path_name.split('gpspath:')[1].split(':key')[0]),
                        'live_path_data': live_path_data,
                        'gps_path_data': gps_path_data,
                        'debug_points': debug_points,
@@ -134,7 +127,7 @@ if __name__ == "__main__":
             offset = 0
             counter = 0
             match_found = False
-            while match_found == False:
+            while not match_found:
                 # for value in old_list:
                 if oldlist[offset+counter] == newlist[counter]:
                     counter += 1

--- a/server/redis_utils.py
+++ b/server/redis_utils.py
@@ -21,11 +21,8 @@ limitations under the License.
 *********************************************************************
 """
 
-from master_process import Robot, RobotCommand, _CMD_WRITE_KEY, _CMD_READ_KEY, _CMD_UPDATE_ROBOT, _CMD_ROBOT_COMMAND, _CMD_ACK, _CMD_READ_KEY_REPLY, _CMD_READ_PATH_KEY
-from gps_tools import GpsPoint, GpsSample
 import pickle
-import sys
-sys.path.append('../vehicle')
+from master_process import RobotCommand
 
 
 def get_energy_segment_key(robot_key):
@@ -84,7 +81,8 @@ def clear_autonomy_hold(redis_client=None, vehicle_name=None, value=None, active
 
 def set_vehicle_autonomy(redis_client=None, vehicle_name=None, speed=None, enable=None, active_site=None):
     if not all((vehicle_name, speed, redis_client)):
-        return "Missing something. No vehicle autonomy set.  {}  {}  {}  {}".format(vehicle_name, speed, enable, redis_client)
+        return "Missing something. No vehicle autonomy set.  {}  {}  {}  {}".format(
+            vehicle_name, speed, enable, redis_client)
     if len(active_site) == 0:
         return "Active site not set. Please load a path."
     # TODO: We have two different versions of getting a command key string now.
@@ -94,8 +92,6 @@ def set_vehicle_autonomy(redis_client=None, vehicle_name=None, speed=None, enabl
     robot_command.activate_autonomy = enable
     robot_command.autonomy_velocity = float(speed)
     redis_client.set(vehicle_command_key, pickle.dumps(robot_command))
-    print("Set vehicle {} autonomy to {}".format(
-        vehicle_command_key, (speed, enable)))
     return "Set vehicle {} autonomy to {}".format(vehicle_command_key, (speed, enable))
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -44,11 +44,9 @@ while True:
         print("Server had some error. Restarting...")
         time.sleep(5)
 
-
 app = Flask(__name__, template_folder="templates")
 app.config['REDIS_URL'] = "redis://:@localhost:6379/0"
 redis_client = FlaskRedis(app)
-
 
 volatile_path = []  # When the robot is streaming a path, save it in RAM here.
 active_site = "twistedfields"
@@ -69,16 +67,13 @@ arrow_icon_path = get_svg_path("arrow.svg")
 
 @app.route('/')
 def map_test():
-    return render_template(
-        'acorn.html'
-    )
+    return render_template('acorn.html')
 
 
-def date_handler(obj): return (
-    obj.isoformat() + "-07:00"
-    if isinstance(obj, (datetime.datetime, datetime.date))
-    else None
-)
+def date_handler(obj):
+    return (obj.isoformat() +
+            "-07:00" if isinstance(obj, (datetime.datetime,
+                                         datetime.date)) else None)
 
 
 @app.route('/api/get_herd_data')
@@ -104,45 +99,81 @@ def robots_to_json(keys):
         except:
             debug_points = []
         # print(json.dumps(robot.gps_path_data[0]._asdict()))
-        robot_entry = {'name': robot.name, 'lat': robot.location.lat, 'lon':
-                       robot.location.lon, 'heading': robot.location.azimuth_degrees,
-                       'speed': robot.speed, 'turn_intent_degrees': robot.turn_intent_degrees,
-                       'voltage': robot.voltage, 'control_state': robot.control_state,
-                       'motor_state': robot.motor_state, 'time_stamp': time_stamp,
-                       'loaded_path_name': "" if not robot.loaded_path_name else robot.loaded_path_name.split('gpspath:')[1].split(':key')[0],
-                       'live_path_data': live_path_data,
-                       'gps_path_data': gps_path_data,
-                       'debug_points': debug_points,
-                       'autonomy_hold': robot.autonomy_hold,
-                       'activate_autonomy': robot.activate_autonomy,
-                       'access_point_name': robot.wifi_ap_name,
-                       'wifi_signal': robot.wifi_strength,
-                       'gps_distances': robot.gps_distances,
-                       'gps_angles': robot.gps_angles,
-                       'gps_distance_rates': robot.gps_path_lateral_error_rates,
-                       'gps_angle_rates': robot.gps_path_angular_error_rates,
-                       'strafeP': robot.strafeP,
-                       'steerP': robot.steerP,
-                       'strafeD': robot.strafeD,
-                       'steerD': robot.steerD,
-                       'autonomy_steer_cmd': robot.autonomy_steer_cmd,
-                       'autonomy_strafe_cmd': robot.autonomy_strafe_cmd,
-                       'simulated_data': robot.simulated_data
-                       # 'front_lat': debug_points[0].lat,
-                       # 'front_lon': debug_points[0].lat,
-                       # 'rear_lat': debug_points[1].lat,
-                       # 'rear_lon': debug_points[1].lat,
-                       # 'front_close_lat': debug_points[2].lat,
-                       # 'front_close_lon': debug_points[2].lat,
-                       # 'rear_close_lat': debug_points[3].lat,
-                       # 'rear_close_lon': debug_points[3].lat,
-                       }
+        robot_entry = {
+            'name':
+            robot.name,
+            'lat':
+            robot.location.lat,
+            'lon':
+            robot.location.lon,
+            'heading':
+            robot.location.azimuth_degrees,
+            'speed':
+            robot.speed,
+            'turn_intent_degrees':
+            robot.turn_intent_degrees,
+            'voltage':
+            robot.voltage,
+            'control_state':
+            robot.control_state,
+            'motor_state':
+            robot.motor_state,
+            'time_stamp':
+            time_stamp,
+            'loaded_path_name':
+            "" if not robot.loaded_path_name else
+            robot.loaded_path_name.split('gpspath:')[1].split(':key')[0],
+            'live_path_data':
+            live_path_data,
+            'gps_path_data':
+            gps_path_data,
+            'debug_points':
+            debug_points,
+            'autonomy_hold':
+            robot.autonomy_hold,
+            'activate_autonomy':
+            robot.activate_autonomy,
+            'access_point_name':
+            robot.wifi_ap_name,
+            'wifi_signal':
+            robot.wifi_strength,
+            'gps_distances':
+            robot.gps_distances,
+            'gps_angles':
+            robot.gps_angles,
+            'gps_distance_rates':
+            robot.gps_path_lateral_error_rates,
+            'gps_angle_rates':
+            robot.gps_path_angular_error_rates,
+            'strafeP':
+            robot.strafeP,
+            'steerP':
+            robot.steerP,
+            'strafeD':
+            robot.strafeD,
+            'steerD':
+            robot.steerD,
+            'autonomy_steer_cmd':
+            robot.autonomy_steer_cmd,
+            'autonomy_strafe_cmd':
+            robot.autonomy_strafe_cmd,
+            'simulated_data':
+            robot.simulated_data
+            # 'front_lat': debug_points[0].lat,
+            # 'front_lon': debug_points[0].lat,
+            # 'rear_lat': debug_points[1].lat,
+            # 'rear_lon': debug_points[1].lat,
+            # 'front_close_lat': debug_points[2].lat,
+            # 'front_close_lon': debug_points[2].lat,
+            # 'rear_close_lat': debug_points[3].lat,
+            # 'rear_close_lon': debug_points[3].lat,
+        }
         # print(robot_entry)
         robots_list.append(robot_entry)
     return robots_list
 
 
-@app.route('/api/save_path', methods=['POST'])
+@app.route('/api/save_path/', methods=['POST'])
 @app.route('/api/save_path/<pathname>', methods=['POST'])
 def save_current_path(pathname=None):
     if request.method == 'POST':
@@ -192,7 +223,8 @@ def set_vehicle_path(pathname=None, vehicle_name=None):
     robot_command.load_path = get_path_key(pathname)
     print(vehicle_command_key)
     redis_client.set(vehicle_command_key, pickle.dumps(robot_command))
-    return "Set vehicle {} path to {}".format(vehicle_command_key, robot_command.load_path)
+    return "Set vehicle {} path to {}".format(vehicle_command_key,
+                                              robot_command.load_path)
 
 
 @app.route('/api/set_gps_recording/<vehicle_name>/<record_gps_path>')
@@ -210,19 +242,27 @@ def set_gps_recording(vehicle_name=None, record_gps_path=None):
     robot_command.record_gps_path = record_gps_path
     print(robot_command.record_gps_path)
     redis_client.set(vehicle_command_key, pickle.dumps(robot_command))
-    return "Set vehicle {} record gps command to {}".format(vehicle_command_key, record_gps_path)
+    return "Set vehicle {} record gps command to {}".format(
+        vehicle_command_key, record_gps_path)
 
 
 @app.route('/api/set_vehicle_autonomy/<vehicle_name>/<speed>/<enable>')
 def set_vehicle_autonomy(vehicle_name=None, speed=None, enable=None):
     enable = enable == "true"
-    return redis_utils.set_vehicle_autonomy(redis_client=redis_client, vehicle_name=vehicle_name, speed=speed, enable=enable, active_site=active_site)
+    return redis_utils.set_vehicle_autonomy(redis_client=redis_client,
+                                            vehicle_name=vehicle_name,
+                                            speed=speed,
+                                            enable=enable,
+                                            active_site=active_site)
 
 
 @app.route('/api/modify_autonomy_hold/<vehicle_name>/<value>')
 def clear_autonomy_hold(vehicle_name=None, value=None):
     value = value == "true"
-    return redis_utils.clear_autonomy_hold(redis_client=redis_client, vehicle_name=vehicle_name, value=value, active_site=active_site)
+    return redis_utils.clear_autonomy_hold(redis_client=redis_client,
+                                           vehicle_name=vehicle_name,
+                                           value=value,
+                                           active_site=active_site)
 
 
 def get_path_key(pathname):
@@ -283,6 +323,7 @@ def send_arrow_paths():
 def send_robot_icon():
     return send_from_directory('../', "robot.svg")
 
+
 # @app.route('/api/get_dense_path/<start>/<end>')
 
 
@@ -291,8 +332,8 @@ def get_dense_path():
     robot_keys = redis_utils.get_robot_keys(redis_client)
     if len(robot_keys) > 0:
         # TODO(tlalexander): support multiple robots in database
-        path = redis_utils.get_dense_path(
-            redis_client=redis_client, robot_key=robot_keys[0])
+        path = redis_utils.get_dense_path(redis_client=redis_client,
+                                          robot_key=robot_keys[0])
         path = [point._asdict() for point in path]
         print(type(path))
         print(type(path[0]))
@@ -303,8 +344,10 @@ def get_dense_path():
 if __name__ == "__main__":
     while True:
         try:
-            app.run(debug=True, use_reloader=True,
-                    host="0.0.0.0", port=int("80"))
+            app.run(debug=True,
+                    use_reloader=True,
+                    host="0.0.0.0",
+                    port=int("80"))
         except:
             print("Server had some error. Restarting...")
             time.sleep(5)

--- a/server/server.py
+++ b/server/server.py
@@ -30,7 +30,6 @@ while True:
         from flask_redis import FlaskRedis
         import re
         import pickle
-        import json
         import datetime
         import redis_utils
         from master_process import RobotCommand
@@ -49,7 +48,7 @@ active_site = "twistedfields"
 
 
 def get_svg_path(filename):
-    p = re.compile('\s+[d][=]["]([M][^"]+)["]')
+    p = re.compile(r'\s+[d][=]["]([M][^"]+)["]')
     with open(filename) as f:
         for line in f:
             matches = p.match(line)
@@ -67,7 +66,10 @@ def map_test():
 
 
 def date_handler(obj):
-    return (obj.isoformat() + "-07:00" if isinstance(obj, (datetime.datetime, datetime.date)) else None)
+    if isinstance(obj, (datetime.datetime, datetime.date)):
+        return obj.isoformat() + "-07:00"
+    else:
+        return None
 
 
 @app.route('/api/get_herd_data')
@@ -93,8 +95,10 @@ def robots_to_json(keys):
         except BaseException:
             debug_points = []
         # print(json.dumps(robot.gps_path_data[0]._asdict()))
-        loaded_path_name = ("" if not robot.loaded_path_name else
-                            robot.loaded_path_name.split('gpspath:')[1].split(':key')[0])
+        loaded_path_name = ""
+        if robot.loaded_path_name:
+            loaded_path_name = robot.loaded_path_name.split('gpspath:')[1].split(':key')[0]
+
         robot_entry = {
             'name': robot.name,
             'lat': robot.location.lat,
@@ -136,6 +140,7 @@ def robots_to_json(keys):
         }
         # print(robot_entry)
         robots_list.append(robot_entry)
+
     return robots_list
 
 

--- a/server/system_manager.py
+++ b/server/system_manager.py
@@ -20,22 +20,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 *********************************************************************
 """
-from master_process import Robot, RobotCommand, _CMD_WRITE_KEY, _CMD_READ_KEY, _CMD_UPDATE_ROBOT, _CMD_ROBOT_COMMAND, _CMD_ACK, _CMD_READ_KEY_REPLY, _CMD_READ_PATH_KEY
-from remote_control_process import CONTROL_ONLINE, CONTROL_AUTONOMY
-import zmq
-import sys
-import threading
 import time
 from datetime import datetime
-from random import randint, random
 import pickle
 import redis
-import psutil
 import redis_utils
+from remote_control_process import CONTROL_ONLINE
 from zmq_server_pirate import REDIS_PORT
 from server import active_site
-# Necessary so pickle can access class definitions from vehicle.
-sys.path.append('../vehicle')
 
 
 AUTONOMY_AT_STARTUP = True
@@ -56,21 +48,17 @@ _LOOP_DELAY_SEC = 2
 
 
 def main():
-    r = redis.Redis(
-        host='localhost',
-        port=REDIS_PORT)
+    r = redis.Redis(host='localhost', port=REDIS_PORT)
     acorn_present = False
-    acorn_activated = False
     acorn_activated_time = 0
     command_object_autonomy_hold_time = 0
     while True:
         keys = redis_utils.get_robot_keys(r)
         for key in keys:
             robot = pickle.loads(r.get(key))
-            command_object = redis_utils.get_command_object_from_robot_key(
-                r, key)
+            command_object = redis_utils.get_command_object_from_robot_key(r, key)
 
-            if command_object.clear_autonomy_hold == True:
+            if command_object.clear_autonomy_hold:
                 if command_object_autonomy_hold_time == 0:
                     command_object_autonomy_hold_time = time.time()
                 elif time.time() - command_object_autonomy_hold_time > _CLEAR_AUTONOMY_HOLD_COMMAND_OBJECT_TIME_SEC:
@@ -86,17 +74,16 @@ def main():
             print("Data age: {} , Control State: {}, Autonomy Hold {}, Activate Autonomy {}".format(
                 data_age, robot.control_state, robot.autonomy_hold, robot.activate_autonomy))
             if data_age < _ONLINE_DATA_AGE_MAXIMUM_SEC:
-                if acorn_present == False:
+                if not acorn_present:
                     print("Acorn present now")
                     acorn_activated_time = time.time()
                     acorn_present = True
                 time_since_activation = time.time() - acorn_activated_time
 
                 if time_since_activation > _ONLINE_SETTLING_TIME_SEC:
-                    if robot.autonomy_hold == True:
+                    if robot.autonomy_hold:
                         if time.time() - acorn_activated_time > _MAXIMUM_TIME_TO_ATTEMPT_AUTONOMY_SEC:
-                            print(
-                                "Exceeded time to attempt autonomy but autonomy hold still active.")
+                            print("Exceeded time to attempt autonomy but autonomy hold still active.")
                             time.sleep(_LONG_PAUSE_SEC)
                             continue
                         print("Clearing Autonomy Hold")
@@ -107,8 +94,10 @@ def main():
                     if AUTONOMY_AT_STARTUP:
                         if robot.control_state == CONTROL_ONLINE:
                             print("Activating Autonomy")
-                            redis_utils.set_vehicle_autonomy(redis_client=r, vehicle_name=robot.name, speed=float(
-                                AUTONOMY_SPEED), enable=True, active_site=active_site)
+                            result = redis_utils.set_vehicle_autonomy(redis_client=r, vehicle_name=robot.name,
+                                                                      speed=float(AUTONOMY_SPEED), enable=True,
+                                                                      active_site=active_site)
+                            print(result)
                         else:
                             print("Could activate autonomy but state is \"{}\", not \"{}\".".format(
                                 robot.control_state, CONTROL_ONLINE))
@@ -140,7 +129,7 @@ if __name__ == "__main__":
 # 'speed': robot.speed, 'turn_intent_degrees': robot.turn_intent_degrees,
 # 'voltage': robot.voltage, 'control_state': robot.control_state,
 # 'motor_state': robot.motor_state, 'time_stamp': time_stamp,
-# 'loaded_path_name': "" if not robot.loaded_path_name else robot.loaded_path_name.split('gpspath:')[1].split(':key')[0],
+# 'loaded_path_name':"" if not robot.loaded_path_name else robot.loaded_path_name.split('gpspath:')[1].split(':key')[0],
 # 'live_path_data' : live_path_data,
 # 'gps_path_data' : gps_path_data,
 # 'debug_points' : debug_points,

--- a/server/zmq_server_pirate.py
+++ b/server/zmq_server_pirate.py
@@ -23,17 +23,15 @@ limitations under the License.
 # Modified from example file
 # Paranoid Pirate Worker by  Daniel Lundin <dln(at)eintr(dot)org>
 
-from master_process import Robot, RobotCommand, _CMD_WRITE_KEY, _CMD_READ_KEY, _CMD_UPDATE_ROBOT, _CMD_ROBOT_COMMAND, _CMD_ACK, _CMD_READ_KEY_REPLY, _CMD_READ_PATH_KEY
 from random import randint
 import time
 import zmq
 import redis
-import pickle
 import zmq_server
-import sys
 
-# Necessary so pickle can access class definitions from vehicle.
-sys.path.append('../vehicle')
+# keep the two imported to keep pickle working
+# TODO: avoid this by moving the class defs to a separate module.
+from master_process import Robot, RobotCommand
 
 REDIS_PORT = 6379
 
@@ -62,10 +60,7 @@ def worker_socket(context, poller):
 
 def main():
 
-    r = redis.Redis(
-        host='localhost',
-        port=REDIS_PORT)
-
+    r = redis.Redis(host='localhost', port=REDIS_PORT)
     context = zmq.Context(1)
     poller = zmq.Poller()
 
@@ -94,10 +89,8 @@ def main():
                 # print(len(frames))
                 # print(frames)
                 ident, zero_frame, idx, command, key, msg = frames
-                return_command, reply = zmq_server.handle_command(
-                    r, command, key, msg)
-                worker.send_multipart(
-                    [ident, zero_frame, idx, return_command, reply])
+                return_command, reply = zmq_server.handle_command(r, command, key, msg)
+                worker.send_multipart([ident, zero_frame, idx, return_command, reply])
 
                 # worker.send_multipart(frames)
                 liveness = HEARTBEAT_LIVENESS

--- a/vehicle/gps.py
+++ b/vehicle/gps.py
@@ -1,0 +1,66 @@
+import time
+import gps_tools
+import rtk_process
+
+class GPS:
+    def __init__(self, logger, simulate_hardware=False):
+        self.logger = logger
+        self.simulate_hardware = simulate_hardware
+        self.simulated_sample = gps_tools.GpsSample(37.353039233,
+                                                    -122.333725682, 100,
+                                                    ("fix", "fix"), 20, 0,
+                                                    time.time(), 0.5)
+        self.last_gps_sample = None
+        self.last_good_gps_sample = None
+        self.gps_buffers = ["", ""]
+        if self.simulate_hardware:
+            self.rtk_socket1 = None
+            self.rtk_socket2 = None
+        else:
+            self.rtk_process.launch_rtk_sub_procs(self.logger)
+            self.rtk_socket1, rtk_socket2 = rtk_process.connect_rtk_procs(self.logger)
+
+    def last_sample(self):
+        """returns the latest GPS sample, either from the GPS device or simulated"""
+        return self.simulated_sample if self.simulate_hardware else self.last_gps_sample
+
+    def last_good_sample(self):
+        """returns the latest good GPS sample (non-nil), either from the GPS device or simulated"""
+        return self.simulated_sample if self.simulate_hardware else self.last_good_gps_sample
+
+    def update_from_device(self, print_gps, retries):
+        """calls the rtk process to get real GPS sample"""
+        self.gps_buffers, self.last_gps_sample = (
+            rtk_process.rtk_loop_once(
+                self.rtk_socket1,
+                self.rtk_socket2,
+                buffers=self.gps_buffers,
+                print_gps=print_gps,
+                last_sample=self.last_gps_sample,
+                retries=retries,
+                logger=self.logger))
+        if self.last_gps_sample is not None:
+            self.last_good_gps_sample = self.last_gps_sample
+        else:
+            # Occasional bad samples are fine. A very old sample will
+            # get flagged in the final checks.
+            self.last_gps_sample = self.last_good_gps_sample
+
+    def update_simulated_sample(self, lat, lon, azimuth_degrees):
+        """update simulated sample, only useful if the device is simulated"""
+        self.simulated_sample = gps_tools.GpsSample(
+            lat, lon, self.simulated_sample.height_m, ("fix", "fix"), 20,
+            azimuth_degrees, time.time(), 0.5)
+
+    def is_dual_fix(self):
+        """check if the last sample is dual fix."""
+        return gps_tools.is_dual_fix(self.last_sample())
+
+    def dump(self):
+        """dump the sample (only if simulated)"""
+        if self.simulate_hardware:
+            self.logger.info(
+                f"Lat: {self.simulated_sample.lat:.10f}, "
+                f"Lon: {self.simulated_sample.lon:.10f}, "
+                f"Azimuth: {self.simulated_sample.azimuth_degrees:.2f}, "
+                f"Distance: {2.8:.4f}, Fixes: ({True}, {True}), Period: {0.100:.2f}")

--- a/vehicle/gps_tools.py
+++ b/vehicle/gps_tools.py
@@ -27,7 +27,6 @@ from geographiclib.geodesic import Geodesic
 import math
 from collections import namedtuple
 import numpy as np
-from scipy.interpolate import splprep, splev
 import copy
 
 
@@ -112,7 +111,7 @@ def find_closest_pt_on_line(pt1, pt2, pt3):
 def get_heading(start_pt, second_pt):
     start_pt = check_point(start_pt)
     second_pt = check_point(second_pt)
-    g = geod.Inverse(start_pt.lat, start_pt.lon, second_pt.lat, second_pt.lon)
+    g = geod.Inverse(start_pt.lat, start_pt.lon, second_pt.lat, second_pt.lon, Geodesic.AZIMUTH)
     return float(g['azi1'])
 
 
@@ -174,14 +173,14 @@ def offset_row(row, distance, direction, copy_data=False, make_dict=True):
         offset_pt = project_point(pt, direction, distance)
         if copy_data:
             try:
-                new_pt = GpsSample(offset_pt.lat, offset_pt.lon,
-                                   pt['height_m'], pt['status'], pt['num_sats'], pt['azimuth_degrees'], pt['time_stamp'], 0)
+                new_pt = GpsSample(offset_pt.lat, offset_pt.lon, pt['height_m'], pt['status'],
+                                   pt['num_sats'], pt['azimuth_degrees'], pt['time_stamp'], 0)
                 print("copy_ok")
-            except:
+            except BaseException:
                 try:
                     new_pt = GpsPoint3D(
                         offset_pt.lat, offset_pt.lon, pt['height_m'])
-                except:
+                except BaseException:
                     pass
         if not new_pt:
             new_pt = offset_pt
@@ -216,7 +215,8 @@ def three_point_turn(points, angle, distance_away, turn_radius, robot_length=2.0
     return [check_point(latlon_point1), check_point(latlon_point2)]
 
 
-def chain_rows(row_list, starting_point, starting_direction, connection_type, forward_navigation_parameters, connector_navigation_parameters, turn_control_vals, nav_path, asdict=False):
+def chain_rows(row_list, starting_point, starting_direction, connection_type, forward_navigation_parameters,
+               connector_navigation_parameters, turn_control_vals, nav_path, asdict=False):
     """
     Given a list of GPS rows, connect each row with a u-turn command.
     """

--- a/vehicle/joystick.py
+++ b/vehicle/joystick.py
@@ -1,0 +1,73 @@
+from evdev import InputDevice, list_devices, categorize, ecodes
+
+_JOYSTICK_MIN = 0.02
+
+
+class Joystick():
+
+    def __init__(self, simulated=False):
+        self.joy = None
+        self.simulated = simulated
+        self.steer, self.throttle, self.strafe = 0.0, 0.0, 0.0
+
+    def __expr__(self):
+        s = "Joystick"
+        if self.simulated:
+            s = "Simulated " + s
+        return f"<{s}: steer {self.steer}, throttle {self.throttle}, strafe {self.strafe}>"
+
+    def connect(self):
+        devices = [InputDevice(fn) for fn in list_devices()]
+        for dev in devices:
+            if "Microsoft" in dev.name:
+                self.joy = dev
+                return
+            if "Logitech" in dev.name:
+                self.joy = dev
+                return
+
+    def get_joystick_values(self, st_old, th_old, stf_old):
+        """
+        get the latest joystick events and map them to steer, throttle, or strafe, until all pending events are drained.
+        when there's no event mapping to a value, the old value is returned.
+        """
+        steer = st_old
+        throttle = th_old
+        strafe = stf_old
+        while self.joy:
+            event = None
+            try:
+                event = self.joy.read_one()
+            except Exception as e:
+                self.logger.error("Joystick read exception: {}".format(e))
+            if event is None:
+                break
+            if event.type != ecodes.EV_ABS:
+                continue
+            absevent = categorize(event)
+            code = ecodes.bytype[absevent.event.type][absevent.event.code]
+            if code == 'ABS_RX':
+                steer = absevent.event.value / 32768.0
+            elif code == 'ABS_Y':
+                throttle = -absevent.event.value / 32768.0
+            elif code == 'ABS_X':
+                strafe = absevent.event.value / 32768.0
+
+        return steer, throttle, strafe
+
+    def update_value(self):
+        if self.simulated and False:  # ???
+            self.steer, self.throttle, self.strafe = 0.0, 0.0, 0.0
+        else:
+            self.steer, self.throttle, self.strafe = self.get_joystick_values(
+                self.steer, self.throttle, self.strafe)
+            if abs(self.throttle) < _JOYSTICK_MIN:
+                self.throttle = 0.0
+            if abs(self.steer) < _JOYSTICK_MIN:
+                self.steer = 0.0
+
+    def activated(self):
+        return abs(self.steer) > 0.1 or abs(self.throttle) > 0.1 or abs(self.strafe) > 0.1
+
+    def clear_steer(self):
+        self.steer = 0.0

--- a/vehicle/master_process.py
+++ b/vehicle/master_process.py
@@ -21,33 +21,28 @@ limitations under the License.
 *********************************************************************
 """
 
-import zmq
-import sys
-import threading
-import time
-from random import randint, random
-import pickle
-import yaml
-import multiprocessing as mp
-import remote_control_process
-import voltage_monitor_process
-import gps_tools
-from motors import STATE_DISCONNECTED
 from datetime import datetime
-import wifi
-import os
-import queue
-import psutil
-import pipe_relay
-import fcntl
-import server_comms
-import rtk_process
 import argparse
-import nvidia_power_process
-from ctypes import c_char_p
 import coloredlogs
 import logging
+import multiprocessing as mp
+import os
+import pickle
+import psutil
 import subprocess
+import time
+import wifi
+import yaml
+import zmq
+
+import gps_tools
+from motors import STATE_DISCONNECTED
+import nvidia_power_process
+from remote_control_process import run_control, CONTROL_STARTUP
+import server_comms
+import voltage_monitor_process
+from utils import AppendFIFO
+
 
 _YAML_NAME_LOCAL = "vehicle/server_config.yaml"
 _YAML_NAME_RASPBERRY = "/home/pi/vehicle/server_config.yaml"
@@ -90,14 +85,12 @@ _LOGGER_DATE_FORMAT = '%m/%d/%Y %I:%M:%S %p'
 _LOGGER_LEVEL_INFO = 'INFO'
 _LOGGER_LEVEL_DEBUG = 'DEBUG'
 
-
 def kill_main_procs():
     for proc in psutil.process_iter():
         # check whether the process name matches
         # print(proc.cmdline())
         for item in proc.cmdline():
-            if 'master_process.py' in item and proc.pid != os.getpid(
-            ) and proc.pid != os.getppid():
+            if 'master_process.py' in item and proc.pid != os.getpid() and proc.pid != os.getppid():
                 print(proc.cmdline())
                 proc.kill()
 
@@ -105,8 +98,7 @@ def kill_main_procs():
 class Robot:
     def __init__(self, simulated_data=False, logger=None):
         self.key = ""
-        self.location = gps_tools.GpsSample(0, 0, 0, ("", ""), (0, 0), 0,
-                                            time.time(), 0)
+        self.location = gps_tools.GpsSample(0, 0, 0, ("", ""), (0, 0), 0, time.time(), 0)
         self.voltage = 0.0
         self.cell1 = 0.0
         self.cell2 = 0.0
@@ -116,7 +108,7 @@ class Robot:
         self.site = ""
         self.turn_intent_degrees = 0
         self.speed = 0
-        self.control_state = remote_control_process.CONTROL_STARTUP
+        self.control_state = CONTROL_STARTUP
         self.motor_state = STATE_DISCONNECTED
         self.loaded_path_name = ""
         self.loaded_path = []
@@ -165,8 +157,7 @@ class Robot:
                 self.name = str(config["vehicle_name"])
                 self.server = str(config["server"])
                 self.site = str(config["site"])
-                self.logger.info("Using server from yaml {}".format(
-                    self.server))
+                self.logger.info("Using server from yaml {}".format(self.server))
             except yaml.YAMLError as exc:
                 self.logger.error(
                     "Error! Problem Loading Yaml File. Does it exist?/n"
@@ -182,14 +173,6 @@ class RobotCommand:
         self.autonomy_velocity = 0
         self.record_gps_path = _GPS_RECORDING_CLEAR
 
-
-def AppendFIFO(list, value, max_values):
-    list.append(value)
-    while len(list) > max_values:
-        list.pop(0)
-    return list
-
-
 class MainProcess():
     def __init__(self, simulation, debug):
         self.simulation = simulation
@@ -203,7 +186,6 @@ class MainProcess():
                 self.yaml_path = _YAML_NAME_RASPBERRY
 
     def run(self):
-
         self.logger = logging.getLogger('main')
         if self.debug:
             logger_level = _LOGGER_LEVEL_DEBUG
@@ -226,25 +208,17 @@ class MainProcess():
         # Initialize robot object.
         acorn = Robot(self.simulation, self.logger)
         acorn.setup(self.yaml_path)
-        connected = False
 
         # Setup and start wifi config and monitor process.
         wifi_parent_conn, wifi_child_conn = mp.Pipe()
         wifi_proc = mp.Process(target=wifi.wifi_process,
-                               args=(
-                                   wifi_child_conn,
-                                   logging,
-                                   logging_details,
-                               ))
+                               args=(wifi_child_conn, logging, logging_details,))
         wifi_proc.start()
 
         # Setup and start vision config and monitor process.
         vision_parent_conn, vision_child_conn = mp.Pipe()
         vision_proc = mp.Process(target=nvidia_power_process.nvidia_power_loop,
-                                 args=(
-                                     vision_child_conn,
-                                     self.simulation,
-                                 ))
+                                 args=(vision_child_conn, self.simulation,))
         vision_proc.start()
 
         if self.simulation and _SIMULATION_IGNORE_YAML_SERVER_IP:
@@ -276,7 +250,7 @@ class MainProcess():
         main_to_remote_string["value"] = pickle.dumps(acorn)
 
         remote_control_proc = mp.Process(
-            target=remote_control_process.run_control,
+            target=run_control,
             args=(remote_to_main_lock, main_to_remote_lock,
                   remote_to_main_string, main_to_remote_string, logging,
                   logging_details, self.simulation))
@@ -288,19 +262,16 @@ class MainProcess():
 
         voltage_monitor_parent_conn, voltage_monitor_child_conn = mp.Pipe()
         voltage_proc = mp.Process(target=voltage_monitor_process.sampler_loop,
-                                  args=(
-                                      voltage_monitor_child_conn,
-                                      self.simulation,
-                                  ))
+                                  args=(voltage_monitor_child_conn, self.simulation,))
         voltage_proc.start()
 
         self.message_tracker = []
 
-        reqs = 0
-        robot_id = bytes(acorn.name, encoding='ascii')
+        # reqs = 0
+        # robot_id = bytes(acorn.name, encoding='ascii')
         updated_object = False
         gps_count = 0
-        send_robot_object = False
+        # send_robot_object = False
 
         while True:
 
@@ -315,84 +286,19 @@ class MainProcess():
             # print("4444")
 
             if voltage_monitor_parent_conn.poll():
-                cell1, cell2, cell3, total = voltage_monitor_parent_conn.recv()
-                #acorn.voltage = total
-                acorn.cell1 = cell1
-                acorn.cell2 = cell2
-                acorn.cell3 = cell3
+                acorn.cell1, acorn.cell2, acorn.cell3, total = voltage_monitor_parent_conn.recv()
+                # acorn.voltage = total
                 updated_object = True
 
             while wifi_parent_conn.poll():
-                acorn.wifi_strength, acorn.wifi_ap_name, acorn.cpu_temperature_c = wifi_parent_conn.recv(
-                )
+                acorn.wifi_strength, acorn.wifi_ap_name, acorn.cpu_temperature_c = wifi_parent_conn.recv()
 
             # print("5555")
 
-            read_okay = False
-            try:
-                with remote_to_main_lock:
-                    #acorn_location, acorn.live_path_data, acorn.turn_intent_degrees, acorn.debug_points, acorn.control_state, acorn.motor_state, acorn.autonomy_hold, gps_distance, gps_angle, gps_lateral_rate, gps_angular_rate, strafeP, steerP, strafeD, steerD, autonomy_steer_cmd, autonomy_strafe_cmd, gps_fix, acorn.voltage, energy_segment, acorn.motor_temperatures = pickle.loads(remote_control_parent_conn.recv_pyobj(flags=zmq.NOBLOCK))
-                    acorn_location, acorn.live_path_data, acorn.turn_intent_degrees, acorn.debug_points, acorn.control_state, acorn.motor_state, acorn.autonomy_hold, gps_distance, gps_angle, gps_lateral_rate, gps_angular_rate, strafeP, steerP, strafeD, steerD, autonomy_steer_cmd, autonomy_strafe_cmd, gps_fix, acorn.voltage, energy_segment, acorn.motor_temperatures = pickle.loads(
-                        remote_to_main_string["value"])
-                read_okay = True
-                send_robot_object = True
-                if acorn_location != None:
-                    acorn.location = acorn_location
-                # print("44444")
-            except Exception as e:
-                pass
-                # time.sleep(2)
-                # print(e)
-            if read_okay:
-                if gps_fix:
-                    # print("GPS_FIX")
-                    acorn.autonomy_steer_cmd = AppendFIFO(
-                        acorn.autonomy_steer_cmd, autonomy_steer_cmd,
-                        _MAX_GPS_DISTANCES)
-                    acorn.autonomy_strafe_cmd = AppendFIFO(
-                        acorn.autonomy_strafe_cmd, autonomy_strafe_cmd,
-                        _MAX_GPS_DISTANCES)
-                    acorn.gps_distances = AppendFIFO(acorn.gps_distances,
-                                                     gps_distance,
-                                                     _MAX_GPS_DISTANCES)
-                    acorn.gps_angles = AppendFIFO(acorn.gps_angles, gps_angle,
-                                                  _MAX_GPS_DISTANCES)
-                    acorn.gps_path_lateral_error_rates = AppendFIFO(
-                        acorn.gps_path_lateral_error_rates, gps_lateral_rate,
-                        _MAX_GPS_DISTANCES)
-                    acorn.gps_path_angular_error_rates = AppendFIFO(
-                        acorn.gps_path_angular_error_rates, gps_angular_rate,
-                        _MAX_GPS_DISTANCES)
-                    acorn.strafeP = AppendFIFO(acorn.strafeP, strafeP,
-                                               _MAX_GPS_DISTANCES)
-                    acorn.steerP = AppendFIFO(acorn.steerP, steerP,
-                                              _MAX_GPS_DISTANCES)
-                    acorn.strafeD = AppendFIFO(acorn.strafeD, strafeD,
-                                               _MAX_GPS_DISTANCES)
-                    acorn.steerD = AppendFIFO(acorn.steerD, steerD,
-                                              _MAX_GPS_DISTANCES)
-
-                if energy_segment != None:
-                    acorn.energy_segment_list.append(energy_segment)
-
-                updated_object = True
-                gps_count += 1
-                if gps_count % 10 == 0:
-                    updated_object = True
-                    if acorn.record_gps_command == _GPS_RECORDING_ACTIVATE:
-                        acorn.gps_path_data.append(acorn.location)
-                        self.logger.info(
-                            "APPEND GPS. TEMP PATH LENGTH {}".format(
-                                len(acorn.gps_path_data)))
-                        # print(acorn.gps_path_data)
-                if acorn.record_gps_command == _GPS_RECORDING_PAUSE:
-                    pass
-                if acorn.record_gps_command == _GPS_RECORDING_CLEAR:
-                    acorn.gps_path_data = []
-
+            updated_object |= self.update_from_remote_control(
+                acorn, gps_count, remote_to_main_lock, remote_to_main_string)
             # print("6666")
-            seconds_since_update = (datetime.now() -
-                                    acorn.time_stamp).total_seconds()
+            seconds_since_update = (datetime.now() - acorn.time_stamp).total_seconds()
 
             if self.simulation:
                 period = _SIMULATION_UPDATE_PERIOD
@@ -403,54 +309,14 @@ class MainProcess():
                 acorn.time_stamp = datetime.now()
                 # print(acorn.time_stamp)
                 try:
-                    self.server_comms_parent_conn.send(
-                        [_CMD_UPDATE_ROBOT, acorn.key,
-                         pickle.dumps(acorn)])
+                    self.server_comms_parent_conn.send([_CMD_UPDATE_ROBOT, acorn.key, pickle.dumps(acorn)])
                     acorn.energy_segment_list = []
-                except zmq.error.Again as e:
+                except zmq.error.Again:
                     self.logger.error("Remote server unreachable.")
                 updated_object = False
 
             # print("$$$$$$")
-
-            while self.server_comms_parent_conn.poll():
-                #print("Got new data from server.")
-                command, msg = self.server_comms_parent_conn.recv()
-                #print('Client received command {} with message {}'.format(command, msg))
-                acorn.last_server_communication_stamp = time.time()
-                send_robot_object = True
-
-                # print("7777")
-                if command == _CMD_ROBOT_COMMAND:
-                    robot_command = pickle.loads(msg)
-                    #print("GOT COMMAND: {}".format(robot_command))
-                    if robot_command.load_path != acorn.loaded_path_name and len(
-                            robot_command.load_path) > 0:
-                        self.logger.info("GETTING PATH DATA")
-                        path = self.get_path(robot_command.load_path, acorn)
-                        #    print("8888")
-                        if path:
-                            acorn.loaded_path_name = robot_command.load_path
-                            acorn.loaded_path = path
-                            self.logger.info(acorn.loaded_path_name)
-                            updated_object = True
-                            # print(path)
-
-                    if robot_command.record_gps_path:
-                        acorn.record_gps_command = robot_command.record_gps_path
-                    acorn.activate_autonomy = robot_command.activate_autonomy
-                    acorn.autonomy_velocity = robot_command.autonomy_velocity
-                    acorn.clear_autonomy_hold = robot_command.clear_autonomy_hold
-                    # if acorn.activate_autonomy == True:
-                    #     acorn.request_autonomy_at_startup = False
-                    self.logger.info(
-                        "GPS Path: {}, Autonomy Hold: {}, Activate Autonomy: {}, Autonomy Velocity: {}, Clear Autonomy Hold: {}"
-                        .format(robot_command.record_gps_path,
-                                acorn.autonomy_hold,
-                                robot_command.activate_autonomy,
-                                robot_command.autonomy_velocity,
-                                acorn.clear_autonomy_hold))
-
+            updated_object |= self.update_from_server(acorn)
             # print(time.time())
 
         #    print("((((()))))")
@@ -465,22 +331,22 @@ class MainProcess():
 
         banner = r"""
                                   _____           _
-     /\                          / ____|         | |
-    /  \   ___ ___  _ __ _ __   | (___  _   _ ___| |_ ___ _ __ ___
-   / /\ \ / __/ _ \| '__| '_ \   \___ \| | | / __| __/ _ \ '_ ` _ \
-  / ____ \ (_| (_) | |  | | | |  ____) | |_| \__ \ ||  __/ | | | | |
- /_/    \_\___\___/|_|  |_| |_| |_____/ \__, |___/\__\___|_| |_| |_|
-                                         __/ |
-                                        |___/
-                      _
-                    _(_)_                          wWWWw   _
-        @@@@       (_)@(_)   vVVVv     _     @@@@  (___) _(_)_
-       @@()@@ wWWWw  (_)\    (___)   _(_)_  @@()@@   Y  (_)@(_)
-        @@@@  (___)     `|/    Y    (_)@(_)  @@@@   \|/   (_)\
-         /      Y       \|    \|/    /(_)    \|      |/      |
-      \ |     \ |/       | / \ | /  \|/       |/    \|      \|/
-  jgs \\|//   \\|///  \\\|//\\\|/// \|///  \\\|//  \\|//  \\\|//
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             /\                          / ____|         | |
+            /  \   ___ ___  _ __ _ __   | (___  _   _ ___| |_ ___ _ __ ___
+           / /\ \ / __/ _ \| '__| '_ \   \___ \| | | / __| __/ _ \ '_ ` _ \
+          / ____ \ (_| (_) | |  | | | |  ____) | |_| \__ \ ||  __/ | | | | |
+         /_/    \_\___\___/|_|  |_| |_| |_____/ \__, |___/\__\___|_| |_| |_|
+                                                 __/ |
+                                                |___/
+                              _
+                            _(_)_                          wWWWw   _
+                @@@@       (_)@(_)   vVVVv     _     @@@@  (___) _(_)_
+               @@()@@ wWWWw  (_)\    (___)   _(_)_  @@()@@   Y  (_)@(_)
+                @@@@  (___)     `|/    Y    (_)@(_)  @@@@   \|/   (_)\
+                 /      Y       \|    \|/    /(_)    \|      |/      |
+              \ |     \ |/       | / \ | /  \|/       |/    \|      \|/
+          jgs \\|//   \\|///  \\\|//\\\|/// \|///  \\\|//  \\|//  \\\|//
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         """
         # Flower art by joan stark via https://www.asciiart.eu/plants/flowers
 
@@ -518,8 +384,7 @@ class MainProcess():
                     timeout = _SIMULATION_SERVER_REPLY_TIMEOUT_MILLISECONDS
                 else:
                     timeout = _SERVER_REPLY_TIMEOUT_MILLISECONDS
-                if self.server_comms_parent_conn.poll(timeout=timeout /
-                                                      1000.0):
+                if self.server_comms_parent_conn.poll(timeout=timeout / 1000.0):
                     self.logger.info("READING PATH DATA")
                     command, msg = self.server_comms_parent_conn.recv()
                     if command == _CMD_READ_KEY_REPLY:
@@ -529,12 +394,113 @@ class MainProcess():
                             if key == bytes(pathkey, encoding='ascii'):
                                 return pickle.loads(msg[1])
                             else:
-                                self.logger.error(
-                                    "{} and {} dont match".format(
-                                        key, pathkey))
+                                self.logger.error("{} and {} dont match".format(key, pathkey))
                         else:
                             self.logger.info(msg)
                 attempts += 1
+
+    def update_from_remote_control(self, acorn, gps_count, remote_to_main_lock, remote_to_main_string):
+        updated_object = False
+        read_okay = False
+        try:
+            with remote_to_main_lock:
+                # (acorn_location, acorn.live_path_data, acorn.turn_intent_degrees, acorn.debug_points,
+                # acorn.control_state, acorn.motor_state, acorn.autonomy_hold, gps_distance, gps_angle,
+                # gps_lateral_rate, gps_angular_rate, strafeP, steerP, strafeD, steerD,
+                # autonomy_steer_cmd, autonomy_strafe_cmd, gps_fix, acorn.voltage, energy_segment,
+                # acorn.motor_temperatures) = pickle.loads(remote_control_parent_conn.recv_pyobj(flags=zmq.NOBLOCK))
+                (acorn_location, acorn.live_path_data, acorn.turn_intent_degrees, acorn.debug_points,
+                 acorn.control_state, acorn.motor_state, acorn.autonomy_hold, gps_distance, gps_angle,
+                 gps_lateral_rate, gps_angular_rate, strafeP, steerP, strafeD, steerD,
+                 autonomy_steer_cmd, autonomy_strafe_cmd, gps_fix, acorn.voltage,
+                 energy_segment, acorn.motor_temperatures) = pickle.loads(remote_to_main_string["value"])
+            read_okay = True
+            # send_robot_object = True
+            if acorn_location is not None:
+                acorn.location = acorn_location
+            # print("44444")
+        except Exception:
+            pass
+            # time.sleep(2)
+            # print(e)
+        if read_okay:
+            if gps_fix:
+                # print("GPS_FIX")
+                acorn.autonomy_steer_cmd = AppendFIFO(
+                    acorn.autonomy_steer_cmd, autonomy_steer_cmd,
+                    _MAX_GPS_DISTANCES)
+                acorn.autonomy_strafe_cmd = AppendFIFO(
+                    acorn.autonomy_strafe_cmd, autonomy_strafe_cmd,
+                    _MAX_GPS_DISTANCES)
+                acorn.gps_distances = AppendFIFO(acorn.gps_distances,
+                                                 gps_distance,
+                                                 _MAX_GPS_DISTANCES)
+                acorn.gps_angles = AppendFIFO(acorn.gps_angles, gps_angle,
+                                              _MAX_GPS_DISTANCES)
+                acorn.gps_path_lateral_error_rates = AppendFIFO(
+                    acorn.gps_path_lateral_error_rates, gps_lateral_rate,
+                    _MAX_GPS_DISTANCES)
+                acorn.gps_path_angular_error_rates = AppendFIFO(
+                    acorn.gps_path_angular_error_rates, gps_angular_rate,
+                    _MAX_GPS_DISTANCES)
+                acorn.strafeP = AppendFIFO(acorn.strafeP, strafeP, _MAX_GPS_DISTANCES)
+                acorn.steerP = AppendFIFO(acorn.steerP, steerP, _MAX_GPS_DISTANCES)
+                acorn.strafeD = AppendFIFO(acorn.strafeD, strafeD, _MAX_GPS_DISTANCES)
+                acorn.steerD = AppendFIFO(acorn.steerD, steerD, _MAX_GPS_DISTANCES)
+
+            if energy_segment is not None:
+                acorn.energy_segment_list.append(energy_segment)
+
+            updated_object = True
+            gps_count += 1
+            if gps_count % 10 == 0:
+                if acorn.record_gps_command == _GPS_RECORDING_ACTIVATE:
+                    acorn.gps_path_data.append(acorn.location)
+                    self.logger.info("APPEND GPS. TEMP PATH LENGTH {}".format(len(acorn.gps_path_data)))
+            if acorn.record_gps_command == _GPS_RECORDING_PAUSE:
+                pass
+            if acorn.record_gps_command == _GPS_RECORDING_CLEAR:
+                acorn.gps_path_data = []
+
+        return updated_object
+
+    def update_from_server(self, acorn):
+        updated_object = False
+        while self.server_comms_parent_conn.poll():
+            # print("Got new data from server.")
+            command, msg = self.server_comms_parent_conn.recv()
+            # print('Client received command {} with message {}'.format(command, msg))
+            acorn.last_server_communication_stamp = time.time()
+            # send_robot_object = True
+
+            # print("7777")
+            if command == _CMD_ROBOT_COMMAND:
+                robot_command = pickle.loads(msg)
+                # print("GOT COMMAND: {}".format(robot_command))
+                if robot_command.load_path != acorn.loaded_path_name and len(robot_command.load_path) > 0:
+                    self.logger.info("GETTING PATH DATA")
+                    path = self.get_path(robot_command.load_path, acorn)
+                    #    print("8888")
+                    if path:
+                        acorn.loaded_path_name = robot_command.load_path
+                        acorn.loaded_path = path
+                        self.logger.info(acorn.loaded_path_name)
+                        updated_object = True
+                        # print(path)
+
+                if robot_command.record_gps_path:
+                    acorn.record_gps_command = robot_command.record_gps_path
+                acorn.activate_autonomy = robot_command.activate_autonomy
+                acorn.autonomy_velocity = robot_command.autonomy_velocity
+                acorn.clear_autonomy_hold = robot_command.clear_autonomy_hold
+                # if acorn.activate_autonomy == True:
+                #     acorn.request_autonomy_at_startup = False
+                self.logger.info(f"GPS Path: {robot_command.record_gps_path}, "
+                                 f"Autonomy Hold: {acorn.autonomy_hold}, "
+                                 f"Activate Autonomy: {robot_command.activate_autonomy}, "
+                                 f"Autonomy Velocity: {robot_command.autonomy_velocity}, "
+                                 f"Clear Autonomy Hold: {acorn.clear_autonomy_hold}")
+        return updated_object
 
 
 def run_main(simulation, debug):

--- a/vehicle/motors.py
+++ b/vehicle/motors.py
@@ -193,7 +193,7 @@ class AcornMotorInterface():
             except fibre.protocol.ChannelBrokenException as e:
                 print("Exception in {} odrive.".format(drive.name))
                 raise e
-            except RuntimeError as e:
+            except RuntimeError:
                 print("RuntimeError in {} odrive.".format(drive.name))
                 return True
         return False
@@ -215,8 +215,6 @@ class AcornMotorInterface():
             raise e
 
     def run_debug_control(self, enable_steering=True, enable_traction=True):
-        motor_error = False
-        tick_time = time.time()
         print("RUN_MAIN_MOTORS")
         while True:
             try:
@@ -233,14 +231,14 @@ class AcornMotorInterface():
                     except ValueError as e:
                         print("Unrecoverable error initializing steering.")
                         raise e
-                    except RuntimeError as e:
+                    except RuntimeError:
                         print("Motor problem while initializing steering.")
                 elif not self.steering_adjusted:
                     try:
                         self.steering_adjusted = True
                         self.ask_if_adjust_steering()
                         print("Initialized Steering")
-                    except RuntimeError as e:
+                    except RuntimeError:
                         print("Motor problem while adjusting steering.")
             except Exception as e:
                 print("Exception:")
@@ -262,7 +260,7 @@ class AcornMotorInterface():
                     except ValueError as e:
                         print("Unrecoverable error initializing steering.")
                         raise e
-                    except RuntimeError as e:
+                    except RuntimeError:
                         print("Motor problem while initializing steering.")
                 elif not self.steering_adjusted:
                     try:
@@ -270,7 +268,7 @@ class AcornMotorInterface():
                         if self.manual_control:
                             self.ask_if_adjust_steering()
                         print("Initialized Steering")
-                    except RuntimeError as e:
+                    except RuntimeError:
                         print("Motor problem while adjusting steering.")
 
                 voltages = []
@@ -299,7 +297,7 @@ class AcornMotorInterface():
                 # print(velocities)
 
                 if self.check_odrive_errors():
-                    if motor_error != True:
+                    if not motor_error:
                         # Intentionally break the e-stop loop to stop all motors.
                         time.sleep(1)
                     motor_error = True

--- a/vehicle/remote_control_process.py
+++ b/vehicle/remote_control_process.py
@@ -251,7 +251,7 @@ class RemoteControl():
         throttle = None
         strafe = None
         count = 0
-        while True:
+        while self.joy:
             event = None
             try:
                 event = self.joy.read_one()

--- a/vehicle/remote_control_process.py
+++ b/vehicle/remote_control_process.py
@@ -21,34 +21,30 @@ limitations under the License.
 *********************************************************************
 """
 import corner_actuator
-import serial
 import time
-import sys
 import math
-from odrive.utils import dump_errors
-from evdev import InputDevice, list_devices, categorize, ecodes, KeyEvent
 from steering import calculate_steering, compare_steering_values, steering_to_numpy
 import zmq
 import pickle
 import gps_tools
-from collections import namedtuple
 import numpy as np
 import spline_lib
 import os
 import datetime
 from motors import _STATE_ENABLED, STATE_DISCONNECTED
-import rtk_process
+import gps
 import coloredlogs
 import subprocess
 from enum import Enum
 from multiprocessing import shared_memory, resource_tracker
 import random
+from joystick import Joystick
+from utils import AppendFIFO, clamp
 
 # This file gets imported by server but we should only import GPIO on raspi.
 if "arm" in os.uname().machine:
     import board
     import busio
-    import digitalio
     from adafruit_mcp230xx.mcp23017 import MCP23017
 
 COUNTS_PER_REVOLUTION = corner_actuator.COUNTS_PER_REVOLUTION
@@ -56,7 +52,7 @@ COUNTS_PER_REVOLUTION = corner_actuator.COUNTS_PER_REVOLUTION
 ACCELERATION_COUNTS_SEC = 0.5
 
 _RESUME_MOTION_WARNING_TIME_SEC = 4
-#_RESUME_MOTION_WARNING_TIME_SEC = -1
+# _RESUME_MOTION_WARNING_TIME_SEC = -1
 
 _SEC_IN_ONE_MINUTE = 60
 
@@ -114,8 +110,6 @@ _ERROR_SKIP_RATE = 40
 _DISENGAGEMENT_RETRY_DELAY_MINUTES = 1
 _DISENGAGEMENT_RETRY_DELAY_SEC = _DISENGAGEMENT_RETRY_DELAY_MINUTES * _SEC_IN_ONE_MINUTE
 
-_JOYSTICK_MIN = 0.02
-
 _STEERING_ANGLE_LIMIT_AUTONOMY_DEGREES = 180
 _STEERING_ANGLE_LIMIT_DEGREES = 120
 
@@ -123,11 +117,11 @@ _DEFAULT_MAXIMUM_VELOCITY = 0.4
 
 
 def get_profiled_velocity(last_vel, unfiltered_vel, period_s):
-    if math.fabs(unfiltered_vel-last_vel) < ACCELERATION_COUNTS_SEC * period_s:
-        increment = unfiltered_vel-last_vel
+    if math.fabs(unfiltered_vel - last_vel) < ACCELERATION_COUNTS_SEC * period_s:
+        increment = unfiltered_vel - last_vel
     else:
-        increment = math.copysign(
-            ACCELERATION_COUNTS_SEC, unfiltered_vel-last_vel) * period_s
+        increment = math.copysign(ACCELERATION_COUNTS_SEC,
+                                  unfiltered_vel - last_vel) * period_s
     return last_vel + increment
 
 
@@ -146,7 +140,8 @@ class PathControlValues():
 
 
 class NavigationParameters():
-    def __init__(self, travel_speed, path_following_direction, vehicle_travel_direction, loop_path):
+    def __init__(self, travel_speed, path_following_direction,
+                 vehicle_travel_direction, loop_path):
         self.travel_speed = travel_speed
         self.path_following_direction = path_following_direction
         self.vehicle_travel_direction = vehicle_travel_direction
@@ -154,16 +149,22 @@ class NavigationParameters():
 
 
 class PathSection():
-    def __init__(self, points, control_values, navigation_parameters, max_dist=0,
-                 max_angle=0, end_dist=0, end_angle=0):
-        self.points = points
-        self.spline = None
+    def __init__(self,
+                 points,
+                 control_values,
+                 navigation_parameters,
+                 max_dist=0,
+                 max_angle=0,
+                 end_dist=0,
+                 end_angle=0):
+        self.points: list = points
+        self.spline: spline_lib.GpsSpline = None
         self.maximum_allowed_distance_meters = max_dist
         self.maximum_allowed_angle_error_degrees = max_angle
         self.control_values = control_values
         self.end_distance_m = end_dist
         self.end_angle_degrees = end_angle
-        self.navigation_parameters = navigation_parameters
+        self.navigation_parameters: NavigationParameters = navigation_parameters
 
 
 class EnergySegment():
@@ -178,7 +179,7 @@ class EnergySegment():
         self.duration = end_gps.time_stamp - start_gps.time_stamp
         self.distance_sum = distance_sum
         self.meters_per_second = distance_sum / self.duration
-        self.watt_seconds_per_meter = total_watt_seconds/distance_sum
+        self.watt_seconds_per_meter = total_watt_seconds / distance_sum
         self.height_change = end_gps.height_m - start_gps.height_m
         self.avg_watts = avg_watts
         self.per_motor_total_watt_seconds = per_motor_total_watt_seconds
@@ -190,9 +191,15 @@ class EnergySegment():
 
 
 class RemoteControl():
-
-    def __init__(self, remote_to_main_lock, main_to_remote_lock, remote_to_main_string, main_to_remote_string, logging, logging_details, simulated_hardware=False):
-        self.joy = None
+    def __init__(self,
+                 remote_to_main_lock,
+                 main_to_remote_lock,
+                 remote_to_main_string,
+                 main_to_remote_string,
+                 logging,
+                 logging_details,
+                 simulated_hardware=False):
+        self.joy = Joystick(simulated_hardware)
         self.simulated_hardware = simulated_hardware
         self.motor_socket = None
         self.robot_object = None
@@ -210,149 +217,15 @@ class RemoteControl():
                             datefmt=_LOGGER_DATE_FORMAT,
                             level=_LOGGER_LEVEL,
                             logger=self.logger)
-
-    def run_setup(self):
-        if self.simulated_hardware:
-            class FakeAlarm():
-                def __init__(self):
-                    self.value = 0
-            self.alarm1 = FakeAlarm()
-            self.alarm2 = FakeAlarm()
-            self.alarm3 = FakeAlarm()
-        else:
-            i2c = busio.I2C(board.SCL, board.SDA)
-            mcp = MCP23017(i2c)  # , address=0x20)  # MCP23017
-            self.alarm1 = mcp.get_pin(0)
-            self.alarm2 = mcp.get_pin(1)
-            self.alarm3 = mcp.get_pin(2)
-
-            self.alarm1.switch_to_output(value=False)
-            self.alarm2.switch_to_output(value=False)
-            self.alarm3.switch_to_output(value=False)
-        self.connect_to_motors()
-        self.connect_joystick()
-
-    def connect_to_motors(self, port=5590):
-        context = zmq.Context()
-        #  Socket to talk to motor control process
-        self.motor_socket = context.socket(zmq.REQ)
-        self.motor_socket.connect("tcp://localhost:{}".format(port))
-        self.motor_socket.setsockopt(zmq.LINGER, 50)
-        self.motor_send_okay = True
-        self.motor_last_send_time = time.time()
-
-    def close_motor_socket(self):
-        self.motor_socket.close()
-        del(self.motor_socket)
-        self.motor_socket = None
-
-    def get_joystick_values(self, st_old, th_old, stf_old):
-        steer = None
-        throttle = None
-        strafe = None
-        count = 0
-        while self.joy:
-            event = None
-            try:
-                event = self.joy.read_one()
-            except Exception as e:
-                self.logger.error("Joystick read exception: {}".format(e))
-            if event == None:
-                break
-            if event and event.type == ecodes.EV_ABS:
-                absevent = categorize(event)
-                if ecodes.bytype[absevent.event.type][absevent.event.code] == 'ABS_RX':
-                    steer = absevent.event.value / 32768.0
-                if ecodes.bytype[absevent.event.type][absevent.event.code] == 'ABS_Y':
-                    throttle = -absevent.event.value / 32768.0
-
-                if ecodes.bytype[absevent.event.type][absevent.event.code] == 'ABS_X':
-                    strafe = absevent.event.value / 32768.0
-            count += 1
-
-        if not steer:
-            steer = st_old
-        if not throttle:
-            throttle = th_old
-        if not strafe:
-            strafe = stf_old
-
-        return steer, throttle, strafe
-
-    def connect_joystick(self):
-        devices = [InputDevice(fn) for fn in list_devices()]
-        for dev in devices:
-            if "Microsoft" in dev.name:
-                self.joy = dev
-                return
-            if "Logitech" in dev.name:
-                self.joy = dev
-                return
-
-    def load_path(self, path, simulation_teleport=False, generate_spline=False):
-        self.logger.debug(path)
-        if 'PathSection' in str(type(path)):
-            self.nav_path = path
-            if len(path.points) > 2 and generate_spline == True:
-                self.nav_path.spline = spline_lib.GpsSpline(
-                    path.points, smooth_factor=10, num_points=1000)
-                self.nav_path.points = self.nav_path.spline.points
-            if len(path.points) == 2:
-                self.nav_path.points = gps_tools.check_point(
-                    self.nav_path.points[0]), gps_tools.check_point(self.nav_path.points[1])
-        else:
-            # Legacy paths
-            nav_spline = spline_lib.GpsSpline(
-                path, smooth_factor=10, num_points=1000)
-            self.nav_path = PathSection(points=nav_spline.points, control_values=self.default_path_control_vals, navigation_parameters=self.default_navigation_parameters,
-                                        max_dist=_MAXIMUM_ALLOWED_DISTANCE_METERS, max_angle=_MAXIMUM_ALLOWED_ANGLE_ERROR_DEGREES, end_dist=1.0, end_angle=45)
-            self.nav_path.spline = nav_spline
-        self.loaded_path_name = self.robot_object.loaded_path_name
-        if self.simulated_hardware and simulation_teleport:
-            # Place simulated robot at start of path.
-            if len(self.nav_path.points) == 2:
-                start_index = 0
-            else:
-                start_index = int(len(self.nav_path.spline.points)/2) - 5
-            initial_heading = gps_tools.get_heading(
-                self.nav_path.points[start_index], self.nav_path.points[start_index+1])
-            self.simulated_sample = gps_tools.GpsSample(
-                self.nav_path.points[start_index].lat, self.nav_path.points[start_index].lon, self.simulated_sample.height_m, ("fix", "fix"), 20, initial_heading + 30, time.time(), 0.5)
-            self.latest_gps_sample = self.simulated_sample
-        # Set initial nav_direction.
-        if self.nav_path.navigation_parameters.path_following_direction == Direction.EITHER:
-            dist_start = gps_tools.get_distance(
-                self.latest_gps_sample, self.nav_path.points[0])
-            dist_end = gps_tools.get_distance(
-                self.latest_gps_sample, self.nav_path.points[len(self.nav_path.points)-1])
-            # This may be overridden farther down.
-            if dist_start < dist_end:
-                self.nav_direction = 1
-            else:
-                self.nav_direction = -1
-        elif self.nav_path.navigation_parameters.path_following_direction == Direction.FORWARD:
-            self.nav_direction = 1
-        elif self.nav_path.navigation_parameters.path_following_direction == Direction.BACKWARD:
-            self.nav_direction = -1
-
-    def run_loop(self):
-        joy_steer = 0
-        joy_throttle = 0
-        joy_strafe = 0
-        vel_cmd = 0
-        last_vel_cmd = 0
-        tick_time = time.time()
-
-        #self.default_navigation_parameters = NavigationParameters(travel_speed=0.0, path_following_direction=Direction.BACKWARD, vehicle_travel_direction=Direction.FORWARD, loop_path=True)
-        #self.default_navigation_parameters = NavigationParameters(travel_speed=0.0, path_following_direction=Direction.FORWARD, vehicle_travel_direction=Direction.BACKWARD, loop_path=True)
-        self.default_navigation_parameters = NavigationParameters(
-            travel_speed=0.0, path_following_direction=Direction.EITHER, vehicle_travel_direction=Direction.EITHER, loop_path=True)
-
-        #self.default_navigation_parameters = NavigationParameters(travel_speed=0.0, path_following_direction=Direction.FORWARD, vehicle_travel_direction=Direction.FORWARD, loop_path=True)
-        #self.default_navigation_parameters = NavigationParameters(travel_speed=0.0, path_following_direction=Direction.BACKWARD, vehicle_travel_direction=Direction.BACKWARD, loop_path=True)
-
-        self.default_path_control_vals = PathControlValues(
-            angular_p=0.9, lateral_p=-0.25, angular_d=0.3, lateral_d=-0.05)
+        self.gps = gps.GPS(self.logger, self.simulated_hardware)
+        self.default_navigation_parameters = NavigationParameters(travel_speed=0.0,
+                                                                  path_following_direction=Direction.EITHER,
+                                                                  vehicle_travel_direction=Direction.EITHER,
+                                                                  loop_path=True)
+        self.default_path_control_vals = PathControlValues(angular_p=0.9,
+                                                           lateral_p=-0.25,
+                                                           angular_d=0.3,
+                                                           lateral_d=-0.05)
         self.nav_path = PathSection(points=[],
                                     control_values=self.default_path_control_vals,
                                     navigation_parameters=self.default_navigation_parameters,
@@ -365,16 +238,13 @@ class RemoteControl():
         self.nav_path_index = 0
         self.gps_path = []
         self.load_path_time = time.time()
-        auto_throttle = 0
         self.loaded_path_name = ""
         self.autonomy_hold = True
         self.control_state = CONTROL_STARTUP
         self.motor_state = STATE_DISCONNECTED
         self.driving_direction = 1.0
         self.gps_path_lateral_error = 0
-        self.gps_path_lateral_error_rate = 0
         self.gps_path_angular_error = 0
-        self.gps_path_angular_error_rate = 0
         self.gps_error_update_time = 0
         self.gps_angle_error_rate_averaging_list = []
         self.gps_lateral_error_rate_averaging_list = []
@@ -392,20 +262,114 @@ class RemoteControl():
         self.bus_currents = []
         self.last_energy_segment = None
         self.temperatures = []
-        self.simulated_sample = gps_tools.GpsSample(
-            37.353039233, -122.333725682, 100, ("fix", "fix"), 20, 0, time.time(), 0.5)
-        self.last_calculated_steering = calculate_steering(
-            0, 0, 0, _STEERING_ANGLE_LIMIT_DEGREES)
-        steering_tmp = steering_to_numpy(self.last_calculated_steering)
+        self.last_calculated_steering = calculate_steering(0, 0, 0, _STEERING_ANGLE_LIMIT_DEGREES)
+        self.last_wifi_restart_time = time.time()
+        self.last_vel_cmd = 0
+        self.vel_cmd = 0
+
+        self.loop_count = -1
+
+    def run_setup(self):
+        if self.simulated_hardware:
+
+            class FakeAlarm():
+                def __init__(self):
+                    self.value = 0
+
+            self.alarm1 = FakeAlarm()
+            self.alarm2 = FakeAlarm()
+            self.alarm3 = FakeAlarm()
+        else:
+            i2c = busio.I2C(board.SCL, board.SDA)
+            mcp = MCP23017(i2c)  # , address=0x20)  # MCP23017
+            self.alarm1 = mcp.get_pin(0)
+            self.alarm2 = mcp.get_pin(1)
+            self.alarm3 = mcp.get_pin(2)
+
+            self.alarm1.switch_to_output(value=False)
+            self.alarm2.switch_to_output(value=False)
+            self.alarm3.switch_to_output(value=False)
+        self.connect_to_motors()
+        self.joy.connect()
+
+    def connect_to_motors(self, port=5590):
+        context = zmq.Context()
+        #  Socket to talk to motor control process
+        self.motor_socket = context.socket(zmq.REQ)
+        self.motor_socket.connect("tcp://localhost:{}".format(port))
+        self.motor_socket.setsockopt(zmq.LINGER, 50)
+        self.motor_send_okay = True
+        self.motor_last_send_time = time.time()
+
+    def close_motor_socket(self):
+        self.motor_socket.close()
+        del(self.motor_socket)
+        self.motor_socket = None
+
+    def load_path(self,
+                  path,
+                  simulation_teleport=False,
+                  generate_spline=False):
+        """
+        TODO: doc
+        """
+        if isinstance(path, PathSection):
+            self.nav_path = path
+            if len(path.points) > 2 and generate_spline:
+                self.nav_path.spline = spline_lib.GpsSpline(path.points,
+                                                            smooth_factor=10,
+                                                            num_points=1000)
+                self.nav_path.points = self.nav_path.spline.points
+            elif len(path.points) == 2:
+                self.nav_path.points = tuple(gps_tools.check_point(p) for p in path.points)
+        else:
+            # Legacy paths
+            nav_spline = spline_lib.GpsSpline(path,
+                                              smooth_factor=10,
+                                              num_points=1000)
+            self.nav_path = PathSection(points=nav_spline.points,
+                                        control_values=self.default_path_control_vals,
+                                        navigation_parameters=self.default_navigation_parameters,
+                                        max_dist=_MAXIMUM_ALLOWED_DISTANCE_METERS,
+                                        max_angle=_MAXIMUM_ALLOWED_ANGLE_ERROR_DEGREES,
+                                        end_dist=1.0,
+                                        end_angle=45)
+            self.nav_path.spline = nav_spline
+        self.loaded_path_name = self.robot_object.loaded_path_name
+        if self.simulated_hardware and simulation_teleport:
+            # Place simulated robot at start of path.
+            if len(self.nav_path.points) == 2:
+                start_index = 0
+            else:
+                start_index = int(len(self.nav_path.spline.points)/2) - 5
+            initial_heading = gps_tools.get_heading(
+                self.nav_path.points[start_index], self.nav_path.points[start_index + 1])
+            self.gps.update_simulated_sample(self.nav_path.points[start_index].lat,
+                                             self.nav_path.points[start_index].lon,
+                                             initial_heading + 30)
+
+        # Set initial nav_direction.
+        direction = self.nav_path.navigation_parameters.path_following_direction
+        if direction == Direction.EITHER:
+            dist_start = gps_tools.get_distance(self.gps.last_sample(), self.nav_path.points[0])
+            dist_end = gps_tools.get_distance(
+                self.gps.last_sample(), self.nav_path.points[len(self.nav_path.points) - 1])
+            # This may be overridden farther down.
+            self.nav_direction = 1 if dist_start < dist_end else -1
+        elif direction == Direction.FORWARD:
+            self.nav_direction = 1
+        elif direction == Direction.BACKWARD:
+            self.nav_direction = -1
+
+    def run_loop(self):
         self.reloaded_path = True
 
         # set up shared memory for GUI four wheel steeing debugger (sim only).
+        steering_tmp = steering_to_numpy(self.last_calculated_steering)
         try:
-            self.steering_debug_shared_memory = shared_memory.SharedMemory(
-                name='acorn_steering_debug')
-            self.logger.info(
-                "Connected to existing shared memory acorn_steering_debug")
-        except:
+            self.steering_debug_shared_memory = shared_memory.SharedMemory(name='acorn_steering_debug')
+            self.logger.info("Connected to existing shared memory acorn_steering_debug")
+        except FileNotFoundError:
             self.steering_debug_shared_memory = shared_memory.SharedMemory(
                 name="acorn_steering_debug",
                 create=True,
@@ -413,919 +377,871 @@ class RemoteControl():
             self.logger.info("Created shared memory acorn_steering_debug")
         # Untrack the resource so it does not get destroyed. This allows the
         # steering debug window to stay open.
-        resource_tracker.unregister(
-            self.steering_debug_shared_memory._name, 'shared_memory')
-
-        self.steering_debug = np.ndarray(
-            steering_tmp.shape, dtype=steering_tmp.dtype, buffer=self.steering_debug_shared_memory.buf)
+        resource_tracker.unregister(self.steering_debug_shared_memory._name, 'shared_memory')
+        self.steering_debug = np.ndarray(steering_tmp.shape,
+                                         dtype=steering_tmp.dtype,
+                                         buffer=self.steering_debug_shared_memory.buf)
         self.steering_debug[:] = steering_tmp[:]
-        autonomy_vel_cmd = 0
-        last_wifi_restart_time = 0
-        if self.simulated_hardware:
-            rtk_socket1 = None
-            rtk_socket2 = None
-        else:
-            rtk_process.launch_rtk_sub_procs(self.logger)
-            rtk_socket1, rtk_socket2 = rtk_process.connect_rtk_procs(
-                self.logger)
 
-        self.latest_gps_sample = None
-        self.last_good_gps_sample = None
-        self.gps_buffers = ["", ""]
-        debug_time = time.time()
         try:
-            loop_count = -1
             while True:
-                loop_count += 1
-
-                # Get real or simulated GPS data.
-                if self.simulated_hardware:
-                    if loop_count % GPS_PRINT_INTERVAL == 0:
-                        self.logger.info("Lat: {:.10f}, Lon: {:.10f}, Azimuth: {:.2f}, Distance: {:.4f}, Fixes: ({}, {}), Period: {:.2f}".format(
-                            self.simulated_sample.lat, self.simulated_sample.lon, self.simulated_sample.azimuth_degrees, 2.8, True, True, 0.100))
-                    self.latest_gps_sample = gps_tools.GpsSample(self.simulated_sample.lat, self.simulated_sample.lon, self.simulated_sample.height_m, (
-                        "fix", "fix"), 20, self.simulated_sample.azimuth_degrees, time.time(), 0.5)
-                else:
-                    self.gps_buffers, self.latest_gps_sample = (
-                        rtk_process.rtk_loop_once(rtk_socket1, rtk_socket2,
-                                                  buffers=self.gps_buffers,
-                                                  print_gps=loop_count % GPS_PRINT_INTERVAL == 0,
-                                                  last_sample=self.latest_gps_sample,
-                                                  retries=_GPS_ERROR_RETRIES,
-                                                  logger=self.logger))
-                debug_time = time.time()
-                if self.latest_gps_sample is not None:
-                    self.last_good_gps_sample = self.latest_gps_sample
-                else:
-                    # Occasional bad samples are fine. A very old sample will
-                    # get flagged in the final checks.
-                    self.latest_gps_sample = self.last_good_gps_sample
-
-                try:
-                    # Read robot object from shared memory.
-                    # Object is sent by main process.
-                    recieved_robot_object = None
-                    time1 = time.time() - debug_time
-                    with self.main_to_remote_lock:
-                        recieved_robot_object = pickle.loads(
-                            self.main_to_remote_string["value"])
-                    time2 = time.time() - debug_time
-                except Exception as e:
-                    self.logger.error("Exception reading remote string.")
-                    raise(e)
-                if recieved_robot_object:
-                    if str(type(recieved_robot_object)) == "<class '__main__.Robot'>":
-                        self.robot_object = recieved_robot_object
-                        self.logger.debug("Remote received new robot object.")
-                        time3 = time.time() - debug_time
-                        if len(self.nav_path.points) == 0 or self.loaded_path_name != self.robot_object.loaded_path_name:
-                            if len(self.robot_object.loaded_path) > 0 and self.latest_gps_sample is not None:
-                                if isinstance(self.robot_object.loaded_path[0], PathSection):
-                                    self.nav_path_list = self.robot_object.loaded_path
-                                    if self.simulated_hardware:
-                                        self.nav_path_index = 0
-                                        self.load_path(
-                                            self.nav_path_list[self.nav_path_index], simulation_teleport=True, generate_spline=True)
-                                    else:
-                                        closest_row_index = 0
-                                        min_distance = math.inf
-                                        for index in range(len(self.nav_path_list)):
-                                            row_path = self.nav_path_list[index]
-                                            for point in row_path.points:
-                                                dist = gps_tools.get_distance(
-                                                    self.latest_gps_sample, point)
-                                                if dist < min_distance:
-                                                    min_distance = dist
-                                                    closest_row_index = index
-                                        self.logger.info("Loading path. List length {}, Closest path index {}, min_distance {}".format(
-                                            len(self.nav_path_list), closest_row_index, min_distance))
-                                        self.nav_path_index = closest_row_index
-                                        self.load_path(
-                                            self.nav_path_list[self.nav_path_index], simulation_teleport=True, generate_spline=True)
-                                    self.reloaded_path = True
-                                else:
-                                    self.load_path(
-                                        self.robot_object.loaded_path, simulation_teleport=True, generate_spline=True)
-                                    self.reloaded_path = True
-                                self.load_path_time = time.time()
-
-                        self.activate_autonomy = self.robot_object.activate_autonomy
-                        # self.autonomy_velocity = self.robot_object.autonomy_velocity
-                        # Autonomy is disabled until robot is ready or if joystick is used.
-                        if self.autonomy_hold:
-                            self.activate_autonomy = False
-                        # Reset disabled autonomy if autonomy is turned off in the command.
-                        if self.robot_object.clear_autonomy_hold:
-                            self.autonomy_hold = False
-                            # Reset disengagement timer.
-                            self.disengagement_time = time.time() - _DISENGAGEMENT_RETRY_DELAY_SEC
-
-                if self.robot_object == None:
-                    self.logger.info(
-                        "Waiting for valid robot object before running remote control code.")
-                    time.sleep(_SLOW_POLLING_SLEEP_S)
-                    continue
-
-                time4 = time.time() - debug_time
-
-            #    print("begin robot calc")
-
-                debug_points = (None, None, None, None)
-                calculated_rotation = None
-                calculated_strafe = None
-                gps_lateral_distance_error = 0
-                gps_path_angle_error = 0
-                absolute_path_distance = math.inf
-                time5 = 0
-                strafe_multiplier = 1.0
-                if self.robot_object and self.latest_gps_sample is not None:
-
-                    vehicle_front = gps_tools.project_point(
-                        self.latest_gps_sample, self.latest_gps_sample.azimuth_degrees, 1.0)
-                    vehicle_rear = gps_tools.project_point(
-                        self.latest_gps_sample, self.latest_gps_sample.azimuth_degrees, -1.0)
-
-                    # if time.time() - self.latest_gps_sample.time_stamp > _ALLOWED_SOLUTION_AGE_SEC:
-                    #     self.logger.error("SOLUTION AGE {} NOT OKAY AND LATEST GPS SAMPLE IS: {}".format(time.time() - self.latest_gps_sample.time_stamp, self.latest_gps_sample))
-                    #     self.logger.error("Took {} sec to get here. {} {} {} {}".format(time.time()-debug_time, time1, time2, time3, time4))
-
-                    time5 = time.time() - debug_time
-
-                    """
-                    Begin steering calculation.
-                    TODO: Break this out to a separate module.
-                    """
-
-                    projected_path_tangent_point = gps_tools.GpsPoint(0, 0)
-                    closest_path_point = None
-                    if(len(self.nav_path.points) > 0):
-
-                        path_point_heading = None
-                        if len(self.nav_path.points) == 2:
-                            if self.nav_path.navigation_parameters.vehicle_travel_direction == Direction.EITHER:
-                                closest_path_point = gps_tools.check_point(
-                                    self.nav_path.points[0])
-                            else:
-                                if self.nav_direction == -1:
-                                    closest_path_point = gps_tools.check_point(
-                                        self.nav_path.points[0])
-                                elif self.nav_direction == 1:
-                                    closest_path_point = gps_tools.check_point(
-                                        self.nav_path.points[-1])
-                            path_point_heading = gps_tools.get_heading(
-                                self.nav_path.points[0], self.nav_path.points[1])
-                        else:
-                            closest_u = self.nav_path.spline.closestUOnSpline(
-                                self.latest_gps_sample)
-                            closest_path_point = self.nav_path.spline.coordAtU(
-                                closest_u)
-                            # Heading specified at this point on the path.
-                            path_point_heading = math.degrees(
-                                self.nav_path.spline.slopeRadiansAtU(closest_u))
-                        absolute_path_distance = gps_tools.get_distance(
-                            self.latest_gps_sample, closest_path_point)
-                        calculated_rotation = path_point_heading - \
-                            self.latest_gps_sample.azimuth_degrees
-                        self.logger.debug("calculated_rotation: {}, DISTANCE: {}".format(
-                            calculated_rotation, abs(absolute_path_distance)))
-
-                        projected_path_tangent_point = gps_tools.project_point(
-                            closest_path_point, path_point_heading, 3.0)
-                        gps_lateral_distance_error = gps_tools.get_approx_distance_point_from_line(
-                            self.latest_gps_sample, closest_path_point, projected_path_tangent_point)
-                        self.logger.debug("robot heading {}, path heading {}".format(
-                            self.latest_gps_sample.azimuth_degrees, path_point_heading))
-                        calculated_strafe = gps_lateral_distance_error
-
-                        # Truncate values to between 0 and 360
-                        calculated_rotation %= 360
-
-                        # Set value to +/- 180
-                        if calculated_rotation > 180:
-                            calculated_rotation -= 360
-
-                        self.logger.debug(
-                            "calculated_rotation: {}".format(calculated_rotation))
-
-                        _MAXIMUM_ROTATION_ERROR_DEGREES = 140
-
-                        drive_solution_okay = True
-                        if self.nav_path.navigation_parameters.vehicle_travel_direction == Direction.EITHER:
-                            self.driving_direction = 1
-                            if abs(calculated_rotation) > 90:
-                                calculated_rotation -= math.copysign(
-                                    180, calculated_rotation)
-                                self.driving_direction = -1
-                            if self.nav_direction == -1:
-                                self.driving_direction *= -1
-                                calculated_strafe *= -1
-                        elif self.nav_path.navigation_parameters.vehicle_travel_direction == Direction.FORWARD:
-
-                            self.driving_direction = 1
-                            if abs(calculated_rotation) > _MAXIMUM_ROTATION_ERROR_DEGREES:
-                                if self.nav_path.navigation_parameters.path_following_direction in (Direction.EITHER, Direction.BACKWARD):
-                                    calculated_rotation -= math.copysign(
-                                        180, calculated_rotation)
-                                    calculated_strafe *= -1
-                                    self.nav_direction = -1
-                                if self.nav_path.navigation_parameters.path_following_direction == Direction.FORWARD:
-                                    if abs(calculated_rotation) > _MAXIMUM_ROTATION_ERROR_DEGREES:
-                                        drive_solution_okay = False
-                            elif self.nav_path.navigation_parameters.path_following_direction == Direction.BACKWARD:
-                                drive_solution_okay = False
-
-                        elif self.nav_path.navigation_parameters.vehicle_travel_direction == Direction.BACKWARD:
-                            self.driving_direction = -1
-                            if abs(calculated_rotation) > _MAXIMUM_ROTATION_ERROR_DEGREES:
-                                if self.nav_path.navigation_parameters.path_following_direction in (Direction.EITHER, Direction.FORWARD):
-                                    calculated_rotation -= math.copysign(
-                                        180, calculated_rotation)
-                                    #calculated_strafe *= -1
-                                    self.nav_direction = 1
-                                elif self.nav_path.navigation_parameters.path_following_direction == Direction.BACKWARD:
-                                    if abs(calculated_rotation) > _MAXIMUM_ROTATION_ERROR_DEGREES:
-                                        drive_solution_okay = False
-                            elif self.nav_path.navigation_parameters.path_following_direction == Direction.FORWARD:
-                                drive_solution_okay = False
-                            elif self.nav_path.navigation_parameters.path_following_direction == Direction.BACKWARD:
-                                calculated_strafe *= -1
-
-                        drive_reverse = 1.0
-                        if len(self.nav_path.points) == 2 and self.nav_path.navigation_parameters.path_following_direction == Direction.EITHER:
-                            vehicle_position = (
-                                self.latest_gps_sample.lat, self.latest_gps_sample.lon)
-
-                            if abs(calculated_rotation) > 20:
-                                calculated_strafe_original = calculated_strafe
-                                if abs(calculated_rotation) > 40:
-                                    calculated_strafe = 0
-                                    self.gps_lateral_error_rate_averaging_list = []
-                                else:
-                                    calculated_strafe *= (40 -
-                                                          abs(calculated_rotation))/20.0
-                                self.logger.debug("Reduced strafe from {}, to: {}".format(
-                                    calculated_strafe_original, calculated_strafe))
-                            else:
-                                drive_reverse = gps_tools.determine_point_move_sign(
-                                    self.nav_path.points, vehicle_position)
-                                # Figure out if we're close to aligned with the
-                                # target point and reduce forward or reverse
-                                # velocity if so.
-                                closest_pt_on_line = gps_tools.find_closest_pt_on_line(
-                                    self.nav_path.points[0], self.nav_path.points[1], vehicle_position)
-                                dist_along_line = gps_tools.get_distance(
-                                    self.nav_path.points[0], closest_pt_on_line)
-                                self.logger.debug(
-                                    "dist_along_line {}".format(dist_along_line))
-                                if gps_lateral_distance_error > 1.0:
-                                    # Reduce forward/reverse direction command
-                                    # if we are far from the line but also
-                                    # aligned to the target point.
-                                    if dist_along_line < 1.0:
-                                        drive_reverse = 0
-                                    elif dist_along_line < 2.0:
-                                        drive_reverse *= 0.1
-                                    elif dist_along_line < 4.0:
-                                        drive_reverse *= 0.25
-
-                            self.logger.debug("rotation {}, strafe: {} direction {}, drive_reverse {}".format(
-                                calculated_rotation, calculated_strafe, self.driving_direction, drive_reverse))
-
-                        if not drive_solution_okay:
-                            self.autonomy_hold = True
-                            self.activate_autonomy = False
-                            self.control_state = CONTROL_NO_STEERING_SOLUTION
-                            self.logger.error(
-                                "Could not find drive solution. Disabling autonomy.")
-                            self.logger.error("calculated_rotation: {}, vehicle_travel_direction {}, path_following_direction {}".format(
-                                calculated_rotation, self.nav_path.navigation_parameters.vehicle_travel_direction, self.nav_path.navigation_parameters.path_following_direction))
-
-                        self.logger.debug("calculated_rotation: {}, vehicle_travel_direction {}, path_following_direction {}, self.nav_direction {}, self.driving_direction {}".format(
-                            calculated_rotation, self.nav_path.navigation_parameters.vehicle_travel_direction, self.nav_path.navigation_parameters.path_following_direction, self.nav_direction, self.driving_direction))
-
-                        gps_path_angle_error = calculated_rotation
-                        # Accumulate a list of error values for angular and
-                        # lateral error. This allows averaging of errors
-                        # and also determination of their rate of change.
-                        time_delta = time.time() - self.gps_error_update_time
-                        self.gps_error_update_time = time.time()
-                        if not self.reloaded_path:
-                            self.gps_lateral_error_rate_averaging_list.append(
-                                (gps_lateral_distance_error - self.gps_path_lateral_error) / time_delta)
-                            self.logger.debug("gps_lateral_distance_error: {}, self.gps_path_lateral_error: {}".format(
-                                gps_lateral_distance_error, self.gps_path_lateral_error))
-                            self.gps_angle_error_rate_averaging_list.append(
-                                (gps_path_angle_error - self.gps_path_angular_error) / time_delta)
-                        self.gps_path_angular_error = gps_path_angle_error
-                        self.gps_path_lateral_error = gps_lateral_distance_error
-
-                        # Check end conditions.
-                        if self.nav_direction == -1:
-                            end_distance = gps_tools.get_distance(
-                                self.latest_gps_sample, self.nav_path.points[0])
-                        elif self.nav_direction == 1:
-                            end_distance = gps_tools.get_distance(
-                                self.latest_gps_sample, self.nav_path.points[-1])
-                        if abs(calculated_rotation) < self.nav_path.end_angle_degrees and end_distance < self.nav_path.end_distance_m:
-                            self.logger.info("MET END CONDITIONS {} {}".format(
-                                calculated_rotation, absolute_path_distance))
-                            if self.nav_path.navigation_parameters.loop_path == True:
-                                self.load_path(
-                                    self.nav_path, simulation_teleport=False, generate_spline=False)
-                                self.load_path_time = time.time()
-                                self.gps_lateral_error_rate_averaging_list = []
-                                self.gps_angle_error_rate_averaging_list = []
-                                self.reloaded_path = True
-                                continue
-                            else:
-                                self.nav_path_index += 1
-                                if self.nav_path_index < len(self.nav_path_list):
-                                    self.load_path(
-                                        self.nav_path_list[self.nav_path_index], simulation_teleport=False, generate_spline=True)
-                                    self.gps_angle_error_rate_averaging_list = []
-                                    self.gps_lateral_error_rate_averaging_list = []
-                                    self.reloaded_path = True
-                                    continue
-                                else:
-                                    # self.nav_path_list = []
-                                    self.nav_path_index = 0
-                                    self.load_path(
-                                        self.nav_path_list[self.nav_path_index], simulation_teleport=True, generate_spline=True)
-                                    self.gps_angle_error_rate_averaging_list = []
-                                    self.gps_lateral_error_rate_averaging_list = []
-                                    self.reloaded_path = True
-                                    continue
-                                    # self.control_state = CONTROL_ONLINE
-                                    # self.autonomy_hold = True
-                                    # self.activate_autonomy = False
-
-                        self.reloaded_path = False
-
-                        while len(self.gps_lateral_error_rate_averaging_list) > _ERROR_RATE_AVERAGING_COUNT:
-                            self.gps_lateral_error_rate_averaging_list.pop(0)
-
-                        while len(self.gps_angle_error_rate_averaging_list) > _ERROR_RATE_AVERAGING_COUNT:
-                            self.gps_angle_error_rate_averaging_list.pop(0)
-
-                        if len(self.gps_lateral_error_rate_averaging_list) > 0:
-                            self.gps_path_lateral_error_rate = sum(
-                                self.gps_lateral_error_rate_averaging_list) / len(self.gps_lateral_error_rate_averaging_list)
-                        else:
-                            self.gps_path_lateral_error_rate = 0
-
-                        if len(self.gps_angle_error_rate_averaging_list) > 0:
-                            self.gps_path_angular_error_rate = sum(
-                                self.gps_angle_error_rate_averaging_list) / len(self.gps_angle_error_rate_averaging_list)
-                        else:
-                            self.gps_path_angular_error_rate = 0
-
-                        self.logger.debug("self.gps_path_lateral_error_rate {}, {} / {}".format(self.gps_path_lateral_error_rate, sum(
-                            self.gps_lateral_error_rate_averaging_list), len(self.gps_lateral_error_rate_averaging_list)))
-
-                        self.next_point_heading = calculated_rotation
-
-                    # These extra points can be displayed in the web UI.
-                    # TODO: That's commented out in the server code. Resolve?
-                    debug_points = (vehicle_front, vehicle_rear,
-                                    projected_path_tangent_point, closest_path_point)
-
-                time6 = time.time() - debug_time
-
-                # Get joystick value
-                if self.simulated_hardware and False:
-                    joy_steer, joy_throttle, joy_strafe = 0.0, 0.0, 0.0
-                else:
-                    joy_steer, joy_throttle, joy_strafe = self.get_joystick_values(
-                        joy_steer, joy_throttle, joy_strafe)
-                    if abs(joy_throttle) < _JOYSTICK_MIN:
-                        joy_throttle = 0.0
-                    if abs(joy_steer) < _JOYSTICK_MIN:
-                        joy_steer = 0.0
-
-                # Disable autonomy if manual control is activated.
-                if abs(joy_steer) > 0.1 or abs(joy_throttle) > 0.1 or abs(joy_strafe) > 0.1:
-                    self.logger.info("DISABLED AUTONOMY Steer: {}, Joy {}".format(
-                        joy_steer, joy_throttle))
-                    self.autonomy_hold = True
-                    self.activate_autonomy = False
-                    self.control_state = CONTROL_OVERRIDE
-
-                strafe_d = 0
-                steer_d = 0
-                strafe_p = 0
-                steer_p = 0
-                user_web_page_plot_steer_cmd = 0
-                user_web_page_plot_strafe_cmd = 0
-
-                # Calculate driving commands for autonomy.
-                if self.next_point_heading != -180 and self.activate_autonomy and calculated_rotation != None and calculated_strafe != None:
-
-                    # calculated_rotation *= 2.0
-                    # calculated_strafe *= -0.35
-                    # steer_d = self.gps_path_angular_error_rate * 0.8
-                    # strafe_d = self.gps_path_lateral_error_rate * -0.2
-
-                    steer_p = calculated_rotation * self.nav_path.control_values.angular_p
-                    strafe_p = calculated_strafe * self.nav_path.control_values.lateral_p
-                    steer_d = self.gps_path_angular_error_rate * \
-                        self.nav_path.control_values.angular_d
-                    strafe_d = self.gps_path_lateral_error_rate * \
-                        self.nav_path.control_values.lateral_d
-
-                    # self.logger.debug(self.nav_path.control_values)
-
-                    self.logger.debug("strafe_p {}, strafe_d {}, steer_p {} steer_d {}".format(
-                        strafe_p, strafe_d, strafe_d, steer_d))
-
-                    steer_command_value = steer_p + steer_d
-                    strafe_command_value = strafe_p + strafe_d
-
-                    _STRAFE_LIMIT = 0.25
-                    _STEER_LIMIT = 45
-
-                    # Value clamping
-                    steering_angle = steer_command_value
-                    if steering_angle > _STEER_LIMIT:
-                        steering_angle = _STEER_LIMIT
-                    if steering_angle < -_STEER_LIMIT:
-                        steering_angle = -_STEER_LIMIT
-                    if strafe_command_value > _STRAFE_LIMIT:
-                        unfiltered_strafe_cmd = _STRAFE_LIMIT
-                    if strafe_command_value < -_STRAFE_LIMIT:
-                        unfiltered_strafe_cmd = -_STRAFE_LIMIT
-                    if math.fabs(strafe_command_value) < _STRAFE_LIMIT:
-                        unfiltered_strafe_cmd = strafe_command_value
-
-                    unfiltered_steer_cmd = steering_angle/45.0
-                    unfiltered_strafe_cmd *= self.driving_direction * strafe_multiplier
-
-                    autonomy_steer_diff = unfiltered_steer_cmd - self.last_autonomy_steer_cmd
-                    autonomy_strafe_diff = unfiltered_strafe_cmd - self.last_autonomy_strafe_cmd
-
-                    self.logger.debug("diffs: {}, {}".format(
-                        autonomy_steer_diff * _LOOP_RATE, autonomy_strafe_diff * _LOOP_RATE))
-
-                    # Rate of change clamping
-                    steer_rate = 4.0/_LOOP_RATE
-                    strafe_rate = 40.0/_LOOP_RATE
-                    if autonomy_steer_diff > steer_rate:
-                        autonomy_steer_cmd = self.last_autonomy_steer_cmd + steer_rate
-                    elif autonomy_steer_diff < -steer_rate:
-                        autonomy_steer_cmd = self.last_autonomy_steer_cmd - steer_rate
-                    else:
-                        autonomy_steer_cmd = unfiltered_steer_cmd
-
-                    autonomy_steer_cmd *= self.driving_direction
-
-                    if autonomy_strafe_diff > strafe_rate:
-                        autonomy_strafe_cmd = self.last_autonomy_strafe_cmd + strafe_rate
-                    elif autonomy_strafe_diff < -strafe_rate:
-                        autonomy_strafe_cmd = self.last_autonomy_strafe_cmd - strafe_rate
-                    else:
-                        autonomy_strafe_cmd = unfiltered_strafe_cmd
-
-                    if abs(autonomy_steer_cmd) > 0.8:
-                        # Maxed out steer and strafe can result in strafe only
-                        # due to steering limits, so reduce strafe with maxed
-                        # steering. TODO: linear taper
-                        autonomy_strafe_cmd *= 0.2
-
-                    self.last_autonomy_steer_cmd = autonomy_steer_cmd
-                    self.last_autonomy_strafe_cmd = autonomy_strafe_cmd
-                    user_web_page_plot_steer_cmd = autonomy_steer_cmd * self.driving_direction
-                    user_web_page_plot_strafe_cmd = autonomy_strafe_cmd * self.driving_direction
-
-                    if 0.0 <= self.nav_path.navigation_parameters.travel_speed <= self.maximum_velocity:
-                        autonomy_vel_cmd = self.nav_path.navigation_parameters.travel_speed * \
-                            self.driving_direction * drive_reverse
-                        self.logger.debug("Travel speed: {}".format(
-                            self.nav_path.navigation_parameters.travel_speed))
-                    else:
-                        self.logger.error("Invalid travel speed specified! Got {}. Maximum allowed is {}".format(
-                            self.nav_path.navigation_parameters.travel_speed, self.maximum_velocity))
-                        autonomy_vel_cmd = 0.0
-                    self.logger.debug("self.autonomy_velocity {}, self.driving_direction {}, drive_reverse {} , autonomy_vel_cmd {}".format(
-                        self.autonomy_velocity, self.driving_direction, drive_reverse, autonomy_vel_cmd))
-
-                    joy_steer = 0.0  # ensures that vel goes to zero when autonomy disabled
-                    logger_string = "steer_cmd: {:.2f}, strafe_cmd: {:.2f}, vel_cmd: {:.2f}, calculated_rotation: {:.2f}, calculated_strafe: {:.2f}".format(
-                        autonomy_steer_cmd, autonomy_strafe_cmd, vel_cmd, calculated_rotation, calculated_strafe)
-                    if loop_count % 10 == 0:
-                        self.logger.info(logger_string)
-                    else:
-                        self.logger.debug(logger_string)
-                    #print("Steer: {}, Throttle: {}".format(steer_cmd, vel_cmd))
-                zero_output = False
-
-                # In the following list the order for when we set control state
-                # matters
-                # TODO: clarify? What does this note mean?
-
-                time7 = time.time() - debug_time
-
-                # Begin Safety Checks
-                error_messages = []
-
-                fatal_error = False
-
-                if self.motor_state != _STATE_ENABLED:
-                    error_messages.append(
-                        "Motor error so zeroing out autonomy commands.")
-                    zero_output = True
-                    self.control_state = CONTROL_MOTOR_ERROR
-                    self.resume_motion_timer = time.time()
-
-                if self.voltage_average < _VOLTAGE_CUTOFF:
-                    fatal_error = True
-                    error_messages.append(
-                        "Voltage low so zeroing out autonomy commands.")
-                    zero_output = True
-                    self.control_state = CONTROL_LOW_VOLTAGE
-                    self.resume_motion_timer = time.time()
-
-                if gps_tools.is_dual_fix(self.latest_gps_sample) == False:
-                    error_messages.append(
-                        "No GPS fix so zeroing out autonomy commands.")
-                    zero_output = True
-                    self.control_state = CONTROL_GPS_STARTUP
-                    self.resume_motion_timer = time.time()
-                elif abs(absolute_path_distance) > self.nav_path.maximum_allowed_distance_meters:
-                    # Distance from path exceeds allowed limit.
-                    zero_output = True
-                    self.resume_motion_timer = time.time()
-                    self.control_state = CONTROL_AUTONOMY_ERROR_DISTANCE
-                    error_messages.append("GPS distance {} meters too far from path so zeroing out autonomy commands.".format(
-                        abs(absolute_path_distance)))
-                elif abs(gps_path_angle_error) > self.nav_path.maximum_allowed_angle_error_degrees:
-                    zero_output = True
-                    self.resume_motion_timer = time.time()
-                    self.control_state = CONTROL_AUTONOMY_ERROR_ANGLE
-                    error_messages.append("GPS path angle {} exceeds allowed limit {} so zeroing out autonomy commands.".format(
-                        abs(gps_path_angle_error), self.nav_path.maximum_allowed_angle_error_degrees))
-                elif self.latest_gps_sample.rtk_age > _ALLOWED_RTK_AGE_SEC:
-                    zero_output = True
-                    self.resume_motion_timer = time.time()
-                    self.control_state = CONTROL_AUTONOMY_ERROR_RTK_AGE
-                    error_messages.append(
-                        "RTK base station data too old so zeroing out autonomy commands.")
-                elif time.time() - self.latest_gps_sample.time_stamp > _ALLOWED_SOLUTION_AGE_SEC:
-                    zero_output = True
-                    self.resume_motion_timer = time.time()
-                    self.control_state = CONTROL_AUTONOMY_ERROR_SOLUTION_AGE
-                    error_messages.append(
-                        "RTK solution too old so zeroing out autonomy commands.")
-
-                if time.time() - self.robot_object.last_server_communication_stamp > SERVER_COMMUNICATION_DELAY_LIMIT_SEC:
-                    server_communication_okay = False
-                    zero_output = True
-                    self.resume_motion_timer = time.time()
-                    error_messages.append("Server communication error so zeroing out autonomy commands. Last stamp age {} exceeds allowed age of {} seconds. AP name: {}, Signal Strength {} dbm\r\n".format(
-                        time.time() - self.robot_object.last_server_communication_stamp, SERVER_COMMUNICATION_DELAY_LIMIT_SEC, self.robot_object.wifi_ap_name, self.robot_object.wifi_strength))
-
-                if loop_count % _ERROR_SKIP_RATE == 0:
-                    for error in error_messages:
-                        self.logger.error(error)
-
-                if time.time() > last_wifi_restart_time + 500 and time.time() - self.robot_object.last_server_communication_stamp > _SERVER_DELAY_RECONNECT_WIFI_SECONDS and self.robot_object.last_server_communication_stamp > 0:
-                    self.logger.error("Last Wifi signal strength: {} dbm\r\n".format(
-                        self.robot_object.wifi_strength))
-                    self.logger.error("Last Wifi AP associated: {}\r\n".format(
-                        self.robot_object.wifi_ap_name))
-                    self.logger.error("Restarting wlan1...")
-                    try:
-                        subprocess.check_call(
-                            "ifconfig wlan1 down", shell=True)
-                        subprocess.check_call("ifconfig wlan1 up", shell=True)
-                    except:
-                        pass
-                    last_wifi_restart_time = time.time()
-                    self.logger.error("Restarted wlan1.")
-
-                if zero_output == True:
-                    if self.activate_autonomy and time.time() - self.disengagement_time > _DISENGAGEMENT_RETRY_DELAY_SEC:
-                        self.disengagement_time = time.time()
-                        self.logger.error("Disengaging Autonomy.")
-                        # Ensure we always print errors if we are deactivating autonomy.
-                        if loop_count % _ERROR_SKIP_RATE != 0:
-                            for error in error_messages:
-                                self.logger.error(error)
-                        self.logger.error("Last Wifi signal strength: {} dbm\r\n".format(
-                            self.robot_object.wifi_strength))
-                        self.logger.error("Last Wifi AP associated: {}\r\n".format(
-                            self.robot_object.wifi_ap_name))
-                        self.logger.error("Last CPU Temp: {}\r\n".format(
-                            self.robot_object.cpu_temperature_c))
-                        with open("error_log.txt", 'a+') as file1:
-                            file1.write(
-                                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n")
-                            file1.write("Disegagement Log\r\n")
-                            file1.write(datetime.datetime.now().strftime(
-                                "%a %b %d, %I:%M:%S %p\r\n"))
-                            file1.write("Last Wifi signal strength: {} dbm\r\n".format(
-                                self.robot_object.wifi_strength))
-                            file1.write("Last Wifi AP associated: {}\r\n".format(
-                                self.robot_object.wifi_ap_name))
-                            file1.write("Last CPU Temp: {}\r\n".format(
-                                self.robot_object.cpu_temperature_c))
-                            if self.last_good_gps_sample is not None:
-                                file1.write("Last known GPS location: {}, {}\r\n".format(
-                                    self.last_good_gps_sample.lat, self.last_good_gps_sample.lon))
-                            else:
-                                file1.write("No valid GPS location recorded.")
-                            error_count = 1
-                            for error in error_messages:
-                                file1.write("Error {}: {}\r\n".format(
-                                    error_count, error))
-                                error_count += 1
-                            file1.write(
-                                "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n")
-                        if fatal_error:
-                            self.autonomy_hold = True
-                            self.activate_autonomy = False
-                elif not self.activate_autonomy:
-                    self.resume_motion_timer = time.time()
-                    self.control_state = CONTROL_ONLINE
-
-                time8 = time.time() - debug_time
-
-                # Activate a brief pause at the end of a track.
-                if time.time() - self.load_path_time < _PATH_END_PAUSE_SEC and not zero_output:
-                    zero_output = True
-                    # Don't use the motion timer here as it reactivates alarm.
-                    if loop_count % 10 == 0:
-                        self.logger.info(
-                            "Taking a short delay at the end of the path so zeroing out autonomy commands.")
-
-                if time.time() - self.disengagement_time < _DISENGAGEMENT_RETRY_DELAY_SEC:
-                    zero_output = True
-                    self.resume_motion_timer = time.time()
-                    if loop_count % 10 == 0:
-                        self.logger.info("Disengaged for {:.1f} more seconds so zeroing out autonomy commands.".format(
-                            _DISENGAGEMENT_RETRY_DELAY_SEC - (time.time() - self.disengagement_time)))
-
-                if self.activate_autonomy == True and zero_output == False and time.time() - self.resume_motion_timer < _RESUME_MOTION_WARNING_TIME_SEC:
-                    zero_output = True
-                    self.alarm1.value = True
-                    self.alarm2.value = False
-                    self.alarm3.value = True
-                else:
-                    self.alarm1.value = False
-                    self.alarm2.value = False
-                    self.alarm3.value = False
-
-                # Determine final drive commands.
-                if self.activate_autonomy:
-                    autonomy_time_elapsed = time.time() - self.load_path_time - _PATH_END_PAUSE_SEC
-                    if autonomy_time_elapsed < _BEGIN_AUTONOMY_SPEED_RAMP_SEC:
-                        autonomy_vel_cmd *= autonomy_time_elapsed/_BEGIN_AUTONOMY_SPEED_RAMP_SEC
-                        print(autonomy_time_elapsed)
-                        # autonomy_strafe_cmd = 0
-                    self.control_state = CONTROL_AUTONOMY
-                    if zero_output:
-                        self.control_state = CONTROL_AUTONOMY_PAUSE
-                        vel_cmd = 0.0
-                        steer_cmd = 0.0
-                        strafe_cmd = 0
-                    else:
-                        vel_cmd = autonomy_vel_cmd
-                        steer_cmd = autonomy_steer_cmd
-                        strafe_cmd = autonomy_strafe_cmd
-                else:
-                    if self.voltage_average < _VOLTAGE_CUTOFF:
-                        vel_cmd = 0.0
-                        steer_cmd = 0.0
-                        strafe_cmd = 0
-                        if loop_count % _ERROR_SKIP_RATE == 0:
-                            self.logger.error(
-                                "LOW VOLTAGE PAUSE. Voltage average: {:.2f}".format(self.voltage_average))
-                    else:
-                        vel_cmd = joy_throttle
-                        steer_cmd = joy_steer
-                        if math.fabs(joy_strafe) < 0.1:
-                            strafe_cmd = 0
-                        else:
-                            strafe_cmd = math.copysign(
-                                math.fabs(joy_strafe) - 0.1, joy_strafe)
-
-                # Slow Vel down by 50% when steering is at max.
-                vel_cmd = vel_cmd * 1.0/(1.0 + abs(steer_cmd))
-
-                time8b = time.time() - debug_time
-                # Update master on latest calculations.
-                send_data = (self.latest_gps_sample, self.nav_path.points, self.next_point_heading, debug_points, self.control_state, self.motor_state, self.autonomy_hold, self.gps_path_lateral_error, self.gps_path_angular_error, self.gps_path_lateral_error_rate,
-                             self.gps_path_angular_error_rate, strafe_p, steer_p, strafe_d, steer_d, user_web_page_plot_steer_cmd, user_web_page_plot_strafe_cmd, gps_tools.is_dual_fix(self.latest_gps_sample), self.voltage_average, self.last_energy_segment, self.temperatures)
-
-                with self.remote_to_main_lock:
-                    self.remote_to_main_string["value"] = pickle.dumps(
-                        send_data)
-
-                period = time.time() - tick_time
-                self.last_energy_segment = None
-
-                time9 = time.time() - debug_time
-                vel_cmd = vel_cmd * 0.6  # Fixed factor reduction
-
-                # Perform acceleration on vel_cmd value.
-                profiled_vel = get_profiled_velocity(
-                    last_vel_cmd, vel_cmd, period)
-                self.logger.debug("last_vel_cmd {}, vel_cmd {}, profiled_vel {}".format(
-                    last_vel_cmd, vel_cmd, profiled_vel))
-                vel_cmd = profiled_vel
-                last_vel_cmd = vel_cmd
-                tick_time = time.time()
-
-                steering_limit = _STEERING_ANGLE_LIMIT_DEGREES
-                if len(self.nav_path.points) == 2 and self.activate_autonomy:
-                    steering_limit = _STEERING_ANGLE_LIMIT_AUTONOMY_DEGREES
-                self.logger.debug("Final values: Steer {}, Vel {}, Strafe {}".format(
-                    steer_cmd, vel_cmd, strafe_cmd))
-                calc = calculate_steering(
-                    steer_cmd, vel_cmd, strafe_cmd, steering_limit)
-                self.logger.debug(
-                    "Calculated 4ws values: Steer {}, Vel {}".format(calc, vel_cmd))
-
-                steering_okay, steering_error_string = compare_steering_values(
-                    self.last_calculated_steering, calc)
-                if not steering_okay:
-                    self.logger.error("{}".format(steering_error_string))
-                    self.logger.error("Final values: Steer {}, Vel {}, Strafe {}".format(
-                        steer_cmd, vel_cmd, strafe_cmd))
-                    self.logger.error("old 4ws values: Steer {}".format(
-                        self.last_calculated_steering))
-                    self.logger.error("new 4ws values: Steer {}".format(calc))
-                    # if self.activate_autonomy:
-                    # TODO: the following line is a hack for testing. TLA 9/30/2021
-                    # self.load_path_time = time.time() - _PATH_END_PAUSE_SEC
-                    # calc["front_left"] = (calc["front_left"][0], 0.0)
-                    # calc["front_right"] = (calc["front_right"][0], 0.0)
-                    # calc["rear_left"] = (calc["rear_left"][0], 0.0)
-                    # calc["rear_right"] = (calc["rear_right"][0], 0.0)
-
-                # calc["front_left"] = (0.6, 0.0)
-                # calc["front_right"] = (0.0, 0.0)
-                # calc["rear_left"] = (0.0, 0.0)
-                # calc["rear_right"] = (0.0, 0.0)
-
-                self.last_calculated_steering = calc
-
-                # Send calculated values to shared memory, copying in values
-                # rather than replacing the object.
-                self.steering_debug[:] = steering_to_numpy(calc)[:]
-
-                # if not steering_okay:
-                #     sys.exit()
-
-                # If the robot is simulated, estimate movement odometry.
-                if self.simulated_hardware:
-                    if abs(steer_cmd) > 0.001 or abs(vel_cmd) > 0.001 or abs(strafe_cmd) > 0.001:
-                        steering_multiplier = 0.4
-                        vel_multiplier = 0.5
-                        strafe_multiplier = 0.4
-                        steering_multiplier = 0.4
-                        vel_multiplier = 0.5
-                        strafe_multiplier = 1.0
-                        new_heading_degrees = self.latest_gps_sample.azimuth_degrees + \
-                            steer_cmd * 45.0 * steering_multiplier * self.driving_direction
-                        new_heading_degrees %= 360
-                        next_point = gps_tools.project_point(
-                            self.latest_gps_sample, new_heading_degrees, vel_cmd * vel_multiplier)
-                        # Calculate translation for strafe, which is movement 90 degrees from heading.
-                        next_point = gps_tools.project_point(
-                            next_point, new_heading_degrees + 90, strafe_cmd * strafe_multiplier)
-                        rand_dist = random.uniform(-0.05, 0.05)
-                        rand_angle = random.uniform(0, 360.0)
-                        next_point = gps_tools.project_point(
-                            next_point, rand_angle, rand_dist)
-                        new_heading_degrees += random.uniform(-3.0, 3.0)
-                        self.simulated_sample = gps_tools.GpsSample(
-                            next_point.lat, next_point.lon, self.simulated_sample.height_m, ("fix", "fix"), 20, new_heading_degrees, time.time(), 0.5)
-                if not self.motor_socket:
-                    self.logger.error("Connect to motor control socket")
-                    self.connect_to_motors()
-
-                time10 = 0
-
-                # Try to send final drive commands to motor process.
-                try:
-                    if self.motor_send_okay == True:
-                        # print("send_calc")
-                        self.motor_socket.send_pyobj(
-                            pickle.dumps(calc), flags=zmq.NOBLOCK)
-                        self.motor_send_okay = False
-                        self.motor_last_send_time = time.time()
-
-                    time10 = time.time() - debug_time
-                    # else:
-                    #     print("NOT OKAY TO SEND")
-                    while self.motor_socket.poll(timeout=_VERY_FAST_POLL_MILLISECONDS):
-                        #print("poll motor message")
-                        motor_message = pickle.loads(
-                            self.motor_socket.recv_pyobj())
-                        self.motor_send_okay = True
-                        #print("motor_message: {}".format(motor_message))
-                        try:
-                            self.motor_state = motor_message[0]
-                            self.voltages = motor_message[1]
-                            self.bus_currents = motor_message[2]
-                            self.temperatures = motor_message[3]
-                            self.total_watts = 0
-                            if len(self.voltages) > 0:
-                                self.voltage_average = sum(
-                                    self.voltages)/len(self.voltages)
-                            for volt, current in zip(self.voltages, self.bus_currents):
-                                self.total_watts += volt * current
-                            #print("Drawing {} Watts.".format(int(self.total_watts)))
-                        except Exception as e:
-                            self.logger.error(
-                                "Error reading motor state message.")
-                            self.logger.error(e)
-                            self.motor_state = STATE_DISCONNECTED
-                except zmq.error.Again as e:
-                    self.logger.error("Remote server unreachable.")
-                except zmq.error.ZMQError as e:
-                    self.logger.error(
-                        "ZMQ error with motor command socket. Resetting.")
-                    self.motor_state = STATE_DISCONNECTED
-                    self.close_motor_socket()
-
-                # If we have a GPS fix, update power consumption metrics.
-                if gps_tools.is_dual_fix(self.latest_gps_sample):
-                    # Calculate power consumption metrics in 1 meter segments
-                    self.power_consumption_list.append(
-                        (self.latest_gps_sample, self.total_watts, self.voltages, self.bus_currents))
-                    oldest_power_sample_gps = self.power_consumption_list[0][0]
-                    distance = gps_tools.get_distance(
-                        oldest_power_sample_gps, self.latest_gps_sample)
-                    if distance > 1.0:
-                        total_watt_seconds = 0
-                        watt_average = self.power_consumption_list[0][1]
-                        distance_sum = 0
-                        duration = 0
-                        height_change = 0
-                        last_sample_gps = None
-                        motor_total_watt_seconds = [0, 0, 0, 0]
-                        motor_watt_average = [0, 0, 0, 0]
-                        list_subsamples = []
-                        sample_collector_index = 0
-                        for sample_num in range(1, len(self.power_consumption_list)):
-                            sample1 = self.power_consumption_list[sample_num - 1]
-                            sample2 = self.power_consumption_list[sample_num]
-                            if sample1 == None or sample2 == None:
-                                continue
-                            sample_distance = gps_tools.get_distance(
-                                sample1[0], sample2[0])
-                            sample_duration = sample2[0].time_stamp - \
-                                sample1[0].time_stamp
-                            sample_avg_watts = (sample1[1] + sample2[1])/2.0
-                            if sample_num > sample_collector_index:
-                                list_subsamples.append(sample1[0])
-                                if len(self.power_consumption_list) > _NUM_GPS_SUBSAMPLES:
-                                    sample_collector_index += int(
-                                        len(self.power_consumption_list)/_NUM_GPS_SUBSAMPLES)
-                                else:
-                                    sample_collector_index += 1
-                            # print(sample1[2])
-                            try:
-                                for idx in range(len(sample1[2])):
-                                    motor_watt_average[idx] = (
-                                        sample1[2][idx] * sample1[3][idx] + sample2[2][idx] * sample2[3][idx]) * 0.5
-                                    motor_total_watt_seconds[idx] = motor_watt_average[idx] * \
-                                        sample_duration
-                            except Exception as e:
-                                self.logger.error(e)
-                                self.logger.error(sample1[2])
-                                self.logger.error(sample1[3])
-                            watt_average += sample2[1]
-                            watt_seconds = sample_avg_watts * sample_duration
-                            total_watt_seconds += watt_seconds
-                            distance_sum += sample_distance
-                            last_sample_gps = sample2[0]
-
-                        height_change = last_sample_gps.height_m - oldest_power_sample_gps.height_m
-                        avg_watts = (watt_average) / \
-                            len(self.power_consumption_list)
-                        list_subsamples.append(last_sample_gps)
-
-                        self.last_energy_segment = EnergySegment(loop_count, oldest_power_sample_gps, last_sample_gps, distance_sum, total_watt_seconds, avg_watts,
-                                                                 motor_total_watt_seconds, motor_watt_average, list_subsamples, self.activate_autonomy, self.robot_object.wifi_ap_name, self.robot_object.wifi_strength)
-
-                        # Reset power consumption list.
-                        self.power_consumption_list = []
-                        self.logger.info("                                                                                                                                      Avg watts {:.1f}, watt seconds per meter: {:.1f}, meters per second: {:.2f}, height change {:.2f}".format(
-                            self.last_energy_segment.avg_watts, self.last_energy_segment.watt_seconds_per_meter, self.last_energy_segment.meters_per_second, self.last_energy_segment.height_change))
-
-                if self.simulated_hardware:
-                    time.sleep(_POLL_MILLISECONDS/_MILLISECONDS_PER_SECOND)
-                    # time.sleep(0.1)
-                self.logger.debug("Took {} sec to get here. {} {} {} {} {} {} {} {} {} {} {} {}".format(time.time(
-                )-debug_time, time1, time2, time3, time4, time5, time6, time7, time8, time8b, time9, time10, self.robot_object.wifi_ap_name))
+                self.loop_count += 1
+                self.run_once()
         except KeyboardInterrupt:
             pass
 
+    def run_once(self):
+        tick_time = time.time()
 
-def run_control(remote_to_main_lock, main_to_remote_lock, remote_to_main_string, main_to_remote_string, logging, logging_details, simulated_hardware=False):
-    remote_control = RemoteControl(remote_to_main_lock, main_to_remote_lock, remote_to_main_string,
-                                   main_to_remote_string, logging, logging_details, simulated_hardware)
+        # Get real or simulated GPS data.
+        if self.simulated_hardware:
+            if self.loop_count % GPS_PRINT_INTERVAL == 0:
+                self.gps.dump()
+            s = self.gps.last_sample()
+            self.gps.update_simulated_sample(s.lat, s.lon, s.azimuth_degrees)
+        else:
+            self.gps.update_from_device(print_gps=self.loop_count % GPS_PRINT_INTERVAL == 0,
+                                        retries=_GPS_ERROR_RETRIES,)
+
+        debug_time = time.time()
+        recieved_robot_object = None
+        time1 = time.time() - debug_time
+        try:
+            # Read robot object from shared memory.
+            # Object is sent by main process.
+            with self.main_to_remote_lock:
+                recieved_robot_object = pickle.loads(self.main_to_remote_string["value"])
+            time2 = time.time() - debug_time
+        except Exception as e:
+            self.logger.error("Exception reading remote string.")
+            raise(e)
+
+        # TODO: switch to isinstance() without introducing circular dependency.
+        if str(type(recieved_robot_object)) != "<class '__main__.Robot'>":
+            self.logger.info("Waiting for valid robot object before running remote control code.")
+            time.sleep(_SLOW_POLLING_SLEEP_S)
+            return
+
+        self.robot_object = recieved_robot_object
+        self.logger.debug("Remote received new robot object.")
+        time3 = time.time() - debug_time
+        if not self.nav_path.points or self.loaded_path_name != self.robot_object.loaded_path_name:
+            if self.robot_object.loaded_path and self.gps.last_sample() is not None:
+                self.reload_path()
+        self.activate_autonomy = self.robot_object.activate_autonomy
+        # self.autonomy_velocity = self.robot_object.autonomy_velocity
+        # Autonomy is disabled until robot is ready or if joystick is used.
+        if self.autonomy_hold:
+            self.activate_autonomy = False
+        # Reset disabled autonomy if autonomy is turned off in the command.
+        if self.robot_object.clear_autonomy_hold:
+            self.logger.debug("clearing autonomy hold.")
+            self.autonomy_hold = False
+            # Reset disengagement timer.
+            self.disengagement_time = time.time() - _DISENGAGEMENT_RETRY_DELAY_SEC
+
+        time4 = time.time() - debug_time
+
+        #    print("begin robot calc")
+
+        debug_points = (None, None, None, None)
+        gps_path_angle_error = 0
+        absolute_path_distance = math.inf
+        time5 = 0
+        sample = self.gps.last_sample()
+        if sample is not None:
+            vehicle_front = gps_tools.project_point(sample, sample.azimuth_degrees, 1.0)
+            vehicle_rear = gps_tools.project_point(sample, sample.azimuth_degrees, -1.0)
+
+            time5 = time.time() - debug_time
+            (projected_path_tangent_point, closest_path_point,
+             absolute_path_distance, drive_reverse, calculated_rotation, calculated_strafe) = self.steering_calc()
+
+            # These extra points can be displayed in the web UI.
+            # TODO: That's commented out in the server code. Resolve?
+            debug_points = (vehicle_front, vehicle_rear, projected_path_tangent_point, closest_path_point)
+
+        time6 = time.time() - debug_time
+
+        self.joy.update_value()
+        if self.joy.activated():
+            self.logger.info("DISABLED AUTONOMY becase joystick is activated: {}".format(self.joy))
+            self.autonomy_hold = True
+            self.activate_autonomy = False
+            self.control_state = CONTROL_OVERRIDE
+
+        (user_web_page_plot_steer_cmd, user_web_page_plot_strafe_cmd,
+         strafe_d, steer_d, strafe_p, steer_p,
+         autonomy_vel_cmd, autonomy_steer_cmd, autonomy_strafe_cmd
+         ) = self.calc_commands_for_autonomy(calculated_rotation, calculated_strafe, drive_reverse)
+
+        # In the following list the order for when we set control state
+        # matters
+        # TODO: clarify? What does this note mean?
+
+        time7 = time.time() - debug_time
+
+        error_messages, fatal_error, zero_output = self.safty_checks(absolute_path_distance, gps_path_angle_error)
+
+        if self.loop_count % _ERROR_SKIP_RATE == 0:
+            for error in error_messages:
+                self.logger.error(error)
+
+        self.maybe_restart_wifi()
+
+        if zero_output:
+            if self.activate_autonomy and time.time() - self.disengagement_time > _DISENGAGEMENT_RETRY_DELAY_SEC:
+                self.disengagement_time = time.time()
+                self.logger.error("Disengaging Autonomy.")
+                self.write_errors(error_messages)
+                if fatal_error:
+                    self.autonomy_hold = True
+                    self.activate_autonomy = False
+        elif not self.activate_autonomy:
+            self.resume_motion_timer = time.time()
+            self.control_state = CONTROL_ONLINE
+
+        time8 = time.time() - debug_time
+
+        # Activate a brief pause at the end of a track.
+        if time.time() - self.load_path_time < _PATH_END_PAUSE_SEC and not zero_output:
+            zero_output = True
+            # Don't use the motion timer here as it reactivates alarm.
+            if self.loop_count % 10 == 0:
+                self.logger.info("Taking a short delay at the end of the path so zeroing out autonomy commands.")
+
+        if time.time() - self.disengagement_time < _DISENGAGEMENT_RETRY_DELAY_SEC:
+            zero_output = True
+            self.resume_motion_timer = time.time()
+            if self.loop_count % 10 == 0:
+                self.logger.info(
+                    "Disengaged for {:.1f} more seconds so zeroing out autonomy commands."
+                    .format(_DISENGAGEMENT_RETRY_DELAY_SEC - (time.time() - self.disengagement_time)))
+
+        if (self.activate_autonomy and not zero_output and
+                time.time() - self.resume_motion_timer < _RESUME_MOTION_WARNING_TIME_SEC):
+            zero_output = True
+            self.alarm1.value = True
+            self.alarm2.value = False
+            self.alarm3.value = True
+        else:
+            self.alarm1.value = False
+            self.alarm2.value = False
+            self.alarm3.value = False
+
+        # Determine final drive commands.
+        vel_cmd, steer_cmd, strafe_cmd = self.calc_drive_commands(
+            autonomy_vel_cmd, autonomy_steer_cmd, autonomy_strafe_cmd, zero_output)
+        # Slow Vel down by 50% when steering is at max.
+        self.vel_cmd = vel_cmd * 1.0 / (1.0 + abs(steer_cmd))
+
+        time8b = time.time() - debug_time
+        # Update master on latest calculations.
+        send_data = (self.gps.last_sample(), self.nav_path.points,
+                     self.next_point_heading, debug_points,
+                     self.control_state, self.motor_state,
+                     self.autonomy_hold, self.gps_path_lateral_error,
+                     self.gps_path_angular_error,
+                     self.gps_path_lateral_error_rate(),
+                     self.gps_path_angular_error_rate(),
+                     strafe_p, steer_p, strafe_d, steer_d,
+                     user_web_page_plot_steer_cmd,
+                     user_web_page_plot_strafe_cmd,
+                     self.gps.is_dual_fix(),
+                     self.voltage_average,
+                     self.last_energy_segment,
+                     self.temperatures)
+        with self.remote_to_main_lock:
+            self.remote_to_main_string["value"] = pickle.dumps(send_data)
+
+        period = time.time() - tick_time
+        self.last_energy_segment = None
+
+        time9 = time.time() - debug_time
+        self.vel_cmd = self.vel_cmd * 0.6  # Fixed factor reduction
+
+        # Perform acceleration on self.vel_cmd value.
+        profiled_vel = get_profiled_velocity(self.last_vel_cmd, self.vel_cmd,
+                                             period)
+        self.logger.debug("self.last_vel_cmd {}, self.vel_cmd {}, profiled_vel {}".format(
+            self.last_vel_cmd, self.vel_cmd, profiled_vel))
+        self.vel_cmd = profiled_vel
+        self.last_vel_cmd = self.vel_cmd
+        tick_time = time.time()
+
+        steering_limit = _STEERING_ANGLE_LIMIT_DEGREES
+        if len(self.nav_path.points) == 2 and self.activate_autonomy:
+            steering_limit = _STEERING_ANGLE_LIMIT_AUTONOMY_DEGREES
+        self.logger.debug("Final values: Steer {}, Vel {}, Strafe {}".format(
+            steer_cmd, self.vel_cmd, strafe_cmd))
+        calc = calculate_steering(steer_cmd, self.vel_cmd, strafe_cmd, steering_limit)
+        self.logger.debug("Calculated 4ws values: Steer {}, Vel {}".format(
+            calc, self.vel_cmd))
+
+        steering_okay, steering_error_string = compare_steering_values(
+            self.last_calculated_steering, calc)
+        if not steering_okay:
+            self.logger.error("{}".format(steering_error_string))
+            self.logger.error("Final values: Steer {}, Vel {}, Strafe {}".format(
+                steer_cmd, self.vel_cmd, strafe_cmd))
+            self.logger.error("old 4ws values: Steer {}".format(
+                self.last_calculated_steering))
+            self.logger.error("new 4ws values: Steer {}".format(calc))
+            # if self.activate_autonomy:
+            # TODO: the following line is a hack for testing. TLA 9/30/2021
+            # self.load_path_time = time.time() - _PATH_END_PAUSE_SEC
+            # calc["front_left"] = (calc["front_left"][0], 0.0)
+            # calc["front_right"] = (calc["front_right"][0], 0.0)
+            # calc["rear_left"] = (calc["rear_left"][0], 0.0)
+            # calc["rear_right"] = (calc["rear_right"][0], 0.0)
+
+        # calc["front_left"] = (0.6, 0.0)
+        # calc["front_right"] = (0.0, 0.0)
+        # calc["rear_left"] = (0.0, 0.0)
+        # calc["rear_right"] = (0.0, 0.0)
+
+        self.last_calculated_steering = calc
+
+        # Send calculated values to shared memory, copying in values
+        # rather than replacing the object.
+        self.steering_debug[:] = steering_to_numpy(calc)[:]
+
+        # if not steering_okay:
+        #     sys.exit()
+
+        # If the robot is simulated, estimate movement odometry.
+        if self.simulated_hardware:
+            if abs(steer_cmd) > 0.001 or abs(self.vel_cmd) > 0.001 or abs(strafe_cmd) > 0.001:
+                self.simulate_next_gps_sample(steer_cmd, strafe_cmd)
+        if not self.motor_socket:
+            self.logger.error("Connect to motor control socket")
+            self.connect_to_motors()
+
+        time10 = self.print_power_consumption(calc, debug_time)
+
+        if self.simulated_hardware:
+            time.sleep(_POLL_MILLISECONDS / _MILLISECONDS_PER_SECOND)
+            # time.sleep(0.1)
+        self.logger.debug(
+            "Took {} sec to get here. {} {} {} {} {} {} {} {} {} {} {} {}"
+            .format(time.time() - debug_time, time1, time2, time3,
+                    time4, time5, time6, time7, time8, time8b, time9,
+                    time10, self.robot_object.wifi_ap_name))
+
+    def reload_path(self):
+        if isinstance(self.robot_object.loaded_path[0], PathSection):
+            self.nav_path_list = self.robot_object.loaded_path
+            if self.simulated_hardware:
+                self.nav_path_index = 0
+            else:
+                closest_row_index = 0
+                min_distance = math.inf
+                for index, row_path in enumerate(self.nav_path_list):
+                    for point in row_path.points:
+                        dist = gps_tools.get_distance(self.gps.last_sample(), point)
+                        if dist < min_distance:
+                            min_distance = dist
+                            closest_row_index = index
+                self.logger.info(f"Loading path. "
+                                 f"List length {len(self.nav_path_list)}, "
+                                 f"Closest path index {closest_row_index}, "
+                                 f"min_distance {min_distance}")
+                self.nav_path_index = closest_row_index
+
+            self.load_path(self.nav_path_list[self.nav_path_index],
+                           simulation_teleport=True, generate_spline=True)
+            self.reloaded_path = True
+
+        else:
+            self.load_path(self.robot_object.loaded_path,
+                           simulation_teleport=True, generate_spline=True)
+            self.reloaded_path = True
+        self.load_path_time = time.time()
+
+    def steering_calc(self):
+        """
+        Begin steering calculation.
+        TODO: Break this out to a separate module.
+        """
+
+        if not self.nav_path.points:
+            return (gps_tools.GpsPoint(0, 0),  # projected_path_tangent_point,
+                    None,  # closest_path_point,
+                    math.inf,  # absolute_path_distance,
+                    None,  # drive_reverse,
+                    None,  # calculated_rotation,
+                    None)  # calculated_strafe)
+
+        closest_path_point, path_point_heading = self.calc_closest_path_point_and_heading()
+        absolute_path_distance = gps_tools.get_distance(self.gps.last_sample(), closest_path_point)
+        calculated_rotation = path_point_heading - self.gps.last_sample().azimuth_degrees
+        # Truncate values to between 0 and 360
+        calculated_rotation %= 360
+        # Set value to +/- 180
+        if calculated_rotation > 180:
+            calculated_rotation -= 360
+        self.logger.debug("calculated_rotation: {}, distance to path: {}".format(
+            calculated_rotation, abs(absolute_path_distance)))
+        self.logger.debug("robot heading {}, path heading {}".format(
+            self.gps.last_sample().azimuth_degrees, path_point_heading))
+
+        projected_path_tangent_point = gps_tools.project_point(closest_path_point, path_point_heading, 3.0)
+        gps_lateral_distance_error = gps_tools.get_approx_distance_point_from_line(
+            self.gps.last_sample(), closest_path_point, projected_path_tangent_point)
+        calculated_strafe = gps_lateral_distance_error
+
+        _MAXIMUM_ROTATION_ERROR_DEGREES = 140
+
+        vehicle_dir = self.nav_path.navigation_parameters.vehicle_travel_direction
+        path_dir = self.nav_path.navigation_parameters.path_following_direction
+        drive_solution_okay = (vehicle_dir == Direction.EITHER or
+                               vehicle_dir == path_dir and abs(calculated_rotation) <= _MAXIMUM_ROTATION_ERROR_DEGREES)
+        self.driving_direction = -1 if vehicle_dir == Direction.BACKWARD else 1
+        if vehicle_dir == Direction.EITHER and (abs(calculated_rotation) > 90 or self.nav_direction == -1):
+            self.driving_direction = -1
+
+        if vehicle_dir == Direction.EITHER:
+            if abs(calculated_rotation) > 90:
+                calculated_rotation -= math.copysign(180, calculated_rotation)
+            calculated_strafe *= self.nav_direction
+        elif vehicle_dir == Direction.FORWARD:
+            if (abs(calculated_rotation) > _MAXIMUM_ROTATION_ERROR_DEGREES and
+                    (path_dir in (Direction.EITHER, Direction.BACKWARD))):
+                calculated_rotation -= math.copysign(180, calculated_rotation)
+                calculated_strafe *= -1
+                self.nav_direction = -1
+        elif vehicle_dir == Direction.BACKWARD:
+            if abs(calculated_rotation) > _MAXIMUM_ROTATION_ERROR_DEGREES:
+                if (path_dir in (Direction.EITHER, Direction.FORWARD)):
+                    calculated_rotation -= math.copysign(180, calculated_rotation)
+                    # calculated_strafe *= -1
+                    self.nav_direction = 1
+            elif path_dir == Direction.BACKWARD:
+                calculated_strafe *= -1
+
+        drive_reverse = 1.0
+        if (len(self.nav_path.points) == 2 and path_dir == Direction.EITHER):
+            if abs(calculated_rotation) > 20:
+                original = calculated_strafe
+                if abs(calculated_rotation) > 40:
+                    calculated_strafe = 0
+                    self.gps_lateral_error_rate_averaging_list = []
+                else:
+                    calculated_strafe *= (40 - abs(calculated_rotation)) / 20.0
+                self.logger.debug("Reduced strafe from {}, to: {}".format(original, calculated_strafe))
+            else:
+                vehicle_position = (self.gps.last_sample().lat, self.gps.last_sample().lon)
+                drive_reverse = gps_tools.determine_point_move_sign(
+                    self.nav_path.points, vehicle_position)
+                # Figure out if we're close to aligned with the
+                # target point and reduce forward or reverse
+                # velocity if so.
+                closest_pt_on_line = gps_tools.find_closest_pt_on_line(
+                    self.nav_path.points[0], self.nav_path.points[1],
+                    vehicle_position)
+                dist_along_line = gps_tools.get_distance(self.nav_path.points[0], closest_pt_on_line)
+                self.logger.debug("dist_along_line {}".format(dist_along_line))
+                if gps_lateral_distance_error > 1.0:
+                    # Reduce forward/reverse direction command
+                    # if we are far from the line but also
+                    # aligned to the target point.
+                    if dist_along_line < 1.0:
+                        drive_reverse = 0
+                    elif dist_along_line < 2.0:
+                        drive_reverse *= 0.1
+                    elif dist_along_line < 4.0:
+                        drive_reverse *= 0.25
+
+            self.logger.debug("rotation {}, strafe: {} direction {}, drive_reverse {}".
+                              format(calculated_rotation, calculated_strafe,
+                                     self.driving_direction, drive_reverse))
+
+        if not drive_solution_okay:
+            self.autonomy_hold = True
+            self.activate_autonomy = False
+            self.control_state = CONTROL_NO_STEERING_SOLUTION
+            self.logger.error("Could not find drive solution. Disabling autonomy.")
+            self.logger.error("calculated_rotation: {}, vehicle_travel_direction {}, path_following_direction {}"
+                              .format(calculated_rotation, self.nav_path.
+                                      navigation_parameters.vehicle_travel_direction,
+                                      self.nav_path.navigation_parameters.
+                                      path_following_direction))
+
+        self.logger.debug(
+            f"calculated_rotation: {calculated_rotation}, "
+            f"vehicle_travel_direction {self.nav_path.navigation_parameters.vehicle_travel_direction}, "
+            f"path_following_direction {self.nav_path.navigation_parameters.path_following_direction}, "
+            f"self.nav_direction {self.nav_direction}, "
+            f"self.driving_direction {self.driving_direction}")
+
+        gps_path_angle_error = calculated_rotation
+        # Accumulate a list of error values for angular and
+        # lateral error. This allows averaging of errors
+        # and also determination of their rate of change.
+        time_delta = time.time() - self.gps_error_update_time
+        self.gps_error_update_time = time.time()
+        if not self.reloaded_path:
+            AppendFIFO(self.gps_lateral_error_rate_averaging_list,
+                       (gps_lateral_distance_error - self.gps_path_lateral_error) / time_delta,
+                       _ERROR_RATE_AVERAGING_COUNT)
+            AppendFIFO(self.gps_angle_error_rate_averaging_list,
+                       (gps_path_angle_error - self.gps_path_angular_error) / time_delta,
+                       _ERROR_RATE_AVERAGING_COUNT)
+            self.logger.debug(
+                "gps_lateral_distance_error: {}, self.gps_path_lateral_error: {}"
+                .format(gps_lateral_distance_error, self.gps_path_lateral_error))
+        self.gps_path_angular_error = gps_path_angle_error
+        self.gps_path_lateral_error = gps_lateral_distance_error
+
+        # Check end conditions.
+        pt = self.nav_path.points[0] if self.nav_direction == -1 else self.nav_path.points[-1]
+        end_distance = gps_tools.get_distance(self.gps.last_sample(), pt)
+        if abs(calculated_rotation) < self.nav_path.end_angle_degrees and end_distance < self.nav_path.end_distance_m:
+            self.logger.info("MET END CONDITIONS {} {}".format(calculated_rotation, absolute_path_distance))
+            if self.nav_path.navigation_parameters.loop_path:
+                self.load_path(self.nav_path, simulation_teleport=False, generate_spline=False)
+            else:
+                self.nav_path_index += 1
+                if self.nav_path_index < len(self.nav_path_list):
+                    self.load_path(self.nav_path_list[self.nav_path_index],
+                                   simulation_teleport=False, generate_spline=True)
+                else:
+                    # self.nav_path_list = []
+                    self.nav_path_index = 0
+                    self.load_path(self.nav_path_list[self.nav_path_index],
+                                   simulation_teleport=True, generate_spline=True)
+                    # self.control_state = CONTROL_ONLINE
+                    # self.autonomy_hold = True
+                    # self.activate_autonomy = False
+
+            self.load_path_time = time.time()
+            self.gps_lateral_error_rate_averaging_list = []
+            self.gps_angle_error_rate_averaging_list = []
+            self.reloaded_path = True
+            return (projected_path_tangent_point, closest_path_point, absolute_path_distance,
+                    drive_reverse, calculated_rotation, calculated_strafe)
+
+        self.reloaded_path = False
+        self.logger.debug("self.gps_path_lateral_error_rate {}, {} / {}".format(
+            self.gps_path_lateral_error_rate(),
+            sum(self.gps_lateral_error_rate_averaging_list),
+            len(self.gps_lateral_error_rate_averaging_list)))
+
+        self.next_point_heading = calculated_rotation
+        return (projected_path_tangent_point, closest_path_point, absolute_path_distance,
+                drive_reverse, calculated_rotation, calculated_strafe)
+
+    def calc_closest_path_point_and_heading(self):
+        path_point_heading = None
+        if len(self.nav_path.points) == 2:
+            p0, p1 = self.nav_path.points
+            if self.nav_path.navigation_parameters.vehicle_travel_direction == Direction.EITHER:
+                closest_path_point = gps_tools.check_point(p0)
+            else:
+                if self.nav_direction == -1:
+                    closest_path_point = gps_tools.check_point(p0)
+                elif self.nav_direction == 1:
+                    closest_path_point = gps_tools.check_point(p1)
+            path_point_heading = gps_tools.get_heading(p0, p1)
+        else:
+            closest_u = self.nav_path.spline.closestUOnSpline(self.gps.last_sample())
+            closest_path_point = self.nav_path.spline.coordAtU(closest_u)
+            # Heading specified at this point on the path.
+            path_point_heading = math.degrees(self.nav_path.spline.slopeRadiansAtU(closest_u))
+        return closest_path_point, path_point_heading
+
+    def calc_commands_for_autonomy(self, calculated_rotation, calculated_strafe, drive_reverse):
+        strafe_d = 0
+        steer_d = 0
+        strafe_p = 0
+        steer_p = 0
+        user_web_page_plot_steer_cmd = 0
+        user_web_page_plot_strafe_cmd = 0
+        autonomy_vel_cmd = 0.0
+        autonomy_steer_cmd = 0.0
+        autonomy_strafe_cmd = 0.0
+        strafe_multiplier = 1.0
+
+        # Calculate driving commands for autonomy.
+        if (self.next_point_heading != -180 and self.activate_autonomy and
+                calculated_rotation is not None and calculated_strafe is not None):
+
+            # calculated_rotation *= 2.0
+            # calculated_strafe *= -0.35
+            # steer_d = self.gps_path_angular_error_rate() * 0.8
+            # strafe_d = self.gps_path_lateral_error_rate * -0.2
+
+            steer_p = calculated_rotation * self.nav_path.control_values.angular_p
+            strafe_p = calculated_strafe * self.nav_path.control_values.lateral_p
+            steer_d = self.gps_path_angular_error_rate() * self.nav_path.control_values.angular_d
+            strafe_d = self.gps_path_lateral_error_rate() * self.nav_path.control_values.lateral_d
+
+            self.logger.debug("strafe_p {}, strafe_d {}, steer_p {} steer_d {}".format(
+                strafe_p, strafe_d, strafe_d, steer_d))
+
+            steer_command_value = steer_p + steer_d
+            strafe_command_value = strafe_p + strafe_d
+
+            _STEER_LIMIT = 45
+            unfiltered_steer_cmd = clamp(steer_command_value, -_STEER_LIMIT, _STEER_LIMIT)
+            unfiltered_steer_cmd /= 45.0
+            _STRAFE_LIMIT = 0.25
+            unfiltered_strafe_cmd = clamp(strafe_command_value, -_STRAFE_LIMIT, _STRAFE_LIMIT)
+            unfiltered_strafe_cmd *= self.driving_direction * strafe_multiplier
+
+            autonomy_steer_diff = unfiltered_steer_cmd - self.last_autonomy_steer_cmd
+            autonomy_strafe_diff = unfiltered_strafe_cmd - self.last_autonomy_strafe_cmd
+
+            self.logger.debug("diffs: {}, {}".format(
+                autonomy_steer_diff * _LOOP_RATE, autonomy_strafe_diff * _LOOP_RATE))
+
+            # Rate of change clamping
+            steer_rate = 4.0 / _LOOP_RATE
+            strafe_rate = 40.0 / _LOOP_RATE
+            autonomy_steer_cmd = clamp(unfiltered_steer_cmd,
+                                       self.last_autonomy_steer_cmd - steer_rate,
+                                       self.last_autonomy_steer_cmd + steer_rate)
+            autonomy_steer_cmd *= self.driving_direction
+            autonomy_strafe_cmd = clamp(unfiltered_strafe_cmd,
+                                        self.last_autonomy_strafe_cmd - strafe_rate,
+                                        self.last_autonomy_strafe_cmd + strafe_rate)
+            if abs(autonomy_steer_cmd) > 0.8:
+                # Maxed out steer and strafe can result in strafe only
+                # due to steering limits, so reduce strafe with maxed
+                # steering. TODO: linear taper
+                autonomy_strafe_cmd *= 0.2
+
+            self.last_autonomy_steer_cmd = autonomy_steer_cmd
+            self.last_autonomy_strafe_cmd = autonomy_strafe_cmd
+            user_web_page_plot_steer_cmd = autonomy_steer_cmd * self.driving_direction
+            user_web_page_plot_strafe_cmd = autonomy_strafe_cmd * self.driving_direction
+
+            if 0.0 <= self.nav_path.navigation_parameters.travel_speed <= self.maximum_velocity:
+                autonomy_vel_cmd = (self.nav_path.navigation_parameters.travel_speed
+                                    * self.driving_direction * drive_reverse)
+                self.logger.debug("Travel speed: {}".format(self.nav_path.navigation_parameters.travel_speed))
+            else:
+                self.logger.error("Invalid travel speed specified! Got {}. Maximum allowed is {}"
+                                  .format(self.nav_path.navigation_parameters.travel_speed, self.maximum_velocity))
+                autonomy_vel_cmd = 0.0
+            self.logger.debug(
+                "self.autonomy_velocity {}, self.driving_direction {}, drive_reverse {} , autonomy_vel_cmd {}"
+                .format(self.autonomy_velocity, self.driving_direction,
+                        drive_reverse, autonomy_vel_cmd))
+
+            self.joy.clear_steer()  # ensures that vel goes to zero when autonomy disabled
+            logger_string = (f"steer_cmd: {autonomy_steer_cmd:.2f}, "
+                             f"strafe_cmd: {autonomy_strafe_cmd:.2f}, "
+                             f"vel_cmd: {self.vel_cmd:.2f}, "
+                             f"calculated_rotation: {calculated_rotation:.2f}, "
+                             f"calculated_strafe: {calculated_strafe:.2f}")
+            if self.loop_count % 10 == 0:
+                self.logger.info(logger_string)
+            else:
+                self.logger.debug(logger_string)
+        return (user_web_page_plot_steer_cmd, user_web_page_plot_strafe_cmd,
+                strafe_d, steer_d, strafe_p, steer_p,
+                autonomy_vel_cmd, autonomy_steer_cmd, autonomy_strafe_cmd)
+
+    def safty_checks(self, absolute_path_distance, gps_path_angle_error):
+        # Begin Safety Checks
+        error_messages = []
+        fatal_error = False
+        zero_output = False
+
+        if self.motor_state != _STATE_ENABLED:
+            error_messages.append("Motor error so zeroing out autonomy commands.")
+            zero_output = True
+            self.control_state = CONTROL_MOTOR_ERROR
+            self.resume_motion_timer = time.time()
+
+        if self.voltage_average < _VOLTAGE_CUTOFF:
+            fatal_error = True
+            error_messages.append("Voltage low so zeroing out autonomy commands.")
+            zero_output = True
+            self.control_state = CONTROL_LOW_VOLTAGE
+            self.resume_motion_timer = time.time()
+
+        if not self.gps.is_dual_fix():
+            error_messages.append("No GPS fix so zeroing out autonomy commands.")
+            zero_output = True
+            self.control_state = CONTROL_GPS_STARTUP
+            self.resume_motion_timer = time.time()
+        elif abs(absolute_path_distance) > self.nav_path.maximum_allowed_distance_meters:
+            # Distance from path exceeds allowed limit.
+            zero_output = True
+            self.resume_motion_timer = time.time()
+            self.control_state = CONTROL_AUTONOMY_ERROR_DISTANCE
+            error_messages.append(
+                "GPS distance {} meters too far from path so zeroing out autonomy commands."
+                .format(abs(absolute_path_distance)))
+        elif abs(gps_path_angle_error) > self.nav_path.maximum_allowed_angle_error_degrees:
+            zero_output = True
+            self.resume_motion_timer = time.time()
+            self.control_state = CONTROL_AUTONOMY_ERROR_ANGLE
+            error_messages.append(
+                "GPS path angle {} exceeds allowed limit {} so zeroing out autonomy commands."
+                .format(
+                    abs(gps_path_angle_error),
+                    self.nav_path.maximum_allowed_angle_error_degrees))
+        elif self.gps.last_sample().rtk_age > _ALLOWED_RTK_AGE_SEC:
+            zero_output = True
+            self.resume_motion_timer = time.time()
+            self.control_state = CONTROL_AUTONOMY_ERROR_RTK_AGE
+            error_messages.append("RTK base station data too old so zeroing out autonomy commands.")
+        elif time.time() - self.gps.last_sample().time_stamp > _ALLOWED_SOLUTION_AGE_SEC:
+            zero_output = True
+            self.resume_motion_timer = time.time()
+            self.control_state = CONTROL_AUTONOMY_ERROR_SOLUTION_AGE
+            error_messages.append("RTK solution too old so zeroing out autonomy commands.")
+
+        if time.time() - self.robot_object.last_server_communication_stamp > SERVER_COMMUNICATION_DELAY_LIMIT_SEC:
+            zero_output = True
+            self.resume_motion_timer = time.time()
+            error_messages.append(
+                f"Server communication error so zeroing out autonomy commands. "
+                f"Last stamp age {time.time() - self.robot_object.last_server_communication_stamp} "
+                f"exceeds allowed age of {SERVER_COMMUNICATION_DELAY_LIMIT_SEC} seconds. "
+                f"AP name: {self.robot_object.wifi_ap_name}, "
+                f"Signal Strength {self.robot_object.wifi_strength} dbm\r\n")
+
+        return error_messages, fatal_error, zero_output
+
+    def maybe_restart_wifi(self):
+        if (time.time() > self.last_wifi_restart_time + 500 and
+            time.time() - self.robot_object.last_server_communication_stamp > _SERVER_DELAY_RECONNECT_WIFI_SECONDS and
+                self.robot_object.last_server_communication_stamp > 0):
+            self.logger.error(
+                "Last Wifi signal strength: {} dbm\r\n".format(
+                    self.robot_object.wifi_strength))
+            self.logger.error("Last Wifi AP associated: {}\r\n".format(
+                self.robot_object.wifi_ap_name))
+            self.logger.error("Restarting wlan1...")
+            try:
+                subprocess.check_call("ifconfig wlan1 down",
+                                      shell=True)
+                subprocess.check_call("ifconfig wlan1 up", shell=True)
+            except BaseException:
+                pass
+            self.last_wifi_restart_time = time.time()
+            self.logger.error("Restarted wlan1.")
+
+    def write_errors(self, error_messages):
+        # Ensure we always print errors if we are deactivating autonomy.
+        if self.loop_count % _ERROR_SKIP_RATE != 0:
+            for error in error_messages:
+                self.logger.error(error)
+        self.logger.error("Last Wifi signal strength: {} dbm\r\n".format(
+            self.robot_object.wifi_strength))
+        self.logger.error("Last Wifi AP associated: {}\r\n".format(
+            self.robot_object.wifi_ap_name))
+        self.logger.error("Last CPU Temp: {}\r\n".format(
+            self.robot_object.cpu_temperature_c))
+
+        with open("error_log.txt", 'a+') as file1:
+            file1.write("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n")
+            file1.write("Disegagement Log\r\n")
+            file1.write(datetime.datetime.now().strftime(
+                "%a %b %d, %I:%M:%S %p\r\n"))
+            file1.write("Last Wifi signal strength: {} dbm\r\n".format(
+                self.robot_object.wifi_strength))
+            file1.write("Last Wifi AP associated: {}\r\n".format(
+                self.robot_object.wifi_ap_name))
+            file1.write("Last CPU Temp: {}\r\n".format(
+                self.robot_object.cpu_temperature_c))
+            if self.gps.last_good_sample() is not None:
+                file1.write("Last known GPS location: {}, {}\r\n".
+                            format(self.gps.last_good_sample().lat,
+                                   self.gps.last_good_sample().lon))
+            else:
+                file1.write("No valid GPS location recorded.")
+            error_count = 1
+            for error in error_messages:
+                file1.write("Error {}: {}\r\n".format(error_count, error))
+                error_count += 1
+            file1.write("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n")
+
+    def calc_drive_commands(self, autonomy_vel_cmd, autonomy_steer_cmd, autonomy_strafe_cmd, zero_output):
+        vel_cmd = 0.0
+        steer_cmd = 0.0
+        strafe_cmd = 0
+        if self.activate_autonomy:
+            autonomy_time_elapsed = time.time() - self.load_path_time - _PATH_END_PAUSE_SEC
+            if autonomy_time_elapsed < _BEGIN_AUTONOMY_SPEED_RAMP_SEC:
+                autonomy_vel_cmd *= autonomy_time_elapsed / _BEGIN_AUTONOMY_SPEED_RAMP_SEC
+                print(autonomy_time_elapsed)
+                # autonomy_strafe_cmd = 0
+            self.control_state = CONTROL_AUTONOMY
+            if zero_output:
+                self.control_state = CONTROL_AUTONOMY_PAUSE
+            else:
+                vel_cmd = autonomy_vel_cmd
+                steer_cmd = autonomy_steer_cmd
+                strafe_cmd = autonomy_strafe_cmd
+        else:
+            if self.voltage_average < _VOLTAGE_CUTOFF:
+                if self.loop_count % _ERROR_SKIP_RATE == 0:
+                    self.logger.error(f"LOW VOLTAGE PAUSE. Voltage average: {self.voltage_average:.2f}")
+            else:
+                vel_cmd = self.joy.throttle
+                steer_cmd = self.joy.steer
+                if math.fabs(self.joy.strafe) < 0.1:
+                    strafe_cmd = 0
+                else:
+                    strafe_cmd = math.copysign(math.fabs(self.joy.strafe) - 0.1, self.joy.strafe)
+        return vel_cmd, steer_cmd, strafe_cmd
+
+    def simulate_next_gps_sample(self, steer_cmd, strafe_cmd):
+        steering_multiplier = 0.4
+        vel_multiplier = 0.5
+        steering_multiplier = 0.4
+        vel_multiplier = 0.5
+        strafe_multiplier = 1.0
+        new_heading_degrees = self.gps.last_sample().azimuth_degrees + \
+            steer_cmd * 45.0 * steering_multiplier * self.driving_direction
+        new_heading_degrees %= 360
+        next_point = gps_tools.project_point(self.gps.last_sample(),
+                                             new_heading_degrees,
+                                             self.vel_cmd * vel_multiplier)
+        # Calculate translation for strafe, which is movement 90 degrees from heading.
+        next_point = gps_tools.project_point(next_point,
+                                             new_heading_degrees + 90,
+                                             strafe_cmd * strafe_multiplier)
+        rand_dist = random.uniform(-0.05, 0.05)
+        rand_angle = random.uniform(0, 360.0)
+        next_point = gps_tools.project_point(next_point, rand_angle, rand_dist)
+        new_heading_degrees += random.uniform(-3.0, 3.0)
+        self.gps.update_simulated_sample(next_point.lat, next_point.lon, new_heading_degrees)
+
+    def print_power_consumption(self, calc, debug_time):
+        # Try to send final drive commands to motor process.
+        try:
+            if self.motor_send_okay:
+                # print("send_calc")
+                self.motor_socket.send_pyobj(pickle.dumps(calc),
+                                             flags=zmq.NOBLOCK)
+                self.motor_send_okay = False
+                self.motor_last_send_time = time.time()
+
+            time10 = time.time() - debug_time
+            # else:
+            #     print("NOT OKAY TO SEND")
+            while self.motor_socket.poll(timeout=_VERY_FAST_POLL_MILLISECONDS):
+                # print("poll motor message")
+                motor_message = pickle.loads(self.motor_socket.recv_pyobj())
+                self.motor_send_okay = True
+                # print("motor_message: {}".format(motor_message))
+                try:
+                    self.motor_state, self.voltages, self.bus_currents, self.temperatures = motor_message
+                    self.total_watts = 0
+                    if len(self.voltages) > 0:
+                        self.voltage_average = sum(self.voltages) / len(self.voltages)
+                    for volt, current in zip(self.voltages,
+                                             self.bus_currents):
+                        self.total_watts += volt * current
+                    # print("Drawing {} Watts.".format(int(self.total_watts)))
+                except Exception as e:
+                    self.logger.error("Error reading motor state message.")
+                    self.logger.error(e)
+                    self.motor_state = STATE_DISCONNECTED
+        except zmq.error.Again:
+            self.logger.error("Remote server unreachable.")
+        except zmq.error.ZMQError:
+            self.logger.error("ZMQ error with motor command socket. Resetting.")
+            self.motor_state = STATE_DISCONNECTED
+            self.close_motor_socket()
+
+        # If we have a GPS fix, update power consumption metrics.
+        if self.gps.is_dual_fix():
+            # Calculate power consumption metrics in 1 meter segments
+            self.power_consumption_list.append(
+                (self.gps.last_sample(), self.total_watts,
+                 self.voltages, self.bus_currents))
+            oldest_power_sample_gps = self.power_consumption_list[0][0]
+            distance = gps_tools.get_distance(oldest_power_sample_gps,
+                                              self.gps.last_sample())
+            if distance > 1.0:
+                total_watt_seconds = 0
+                watt_average = self.power_consumption_list[0][1]
+                distance_sum = 0
+                last_sample_gps = None
+                motor_total_watt_seconds = [0, 0, 0, 0]
+                motor_watt_average = [0, 0, 0, 0]
+                list_subsamples = []
+                sample_collector_index = 0
+                for sample_num in range(1, len(self.power_consumption_list)):
+                    sample1 = self.power_consumption_list[sample_num - 1]
+                    sample2 = self.power_consumption_list[sample_num]
+                    if sample1 is None or sample2 is None:
+                        continue
+                    sample_distance = gps_tools.get_distance(sample1[0], sample2[0])
+                    sample_duration = sample2[0].time_stamp - sample1[0].time_stamp
+                    sample_avg_watts = (sample1[1] + sample2[1]) / 2.0
+                    if sample_num > sample_collector_index:
+                        list_subsamples.append(sample1[0])
+                        if len(self.power_consumption_list) > _NUM_GPS_SUBSAMPLES:
+                            sample_collector_index += int(len(self.power_consumption_list)/_NUM_GPS_SUBSAMPLES)
+                        else:
+                            sample_collector_index += 1
+                    # print(sample1[2])
+                    try:
+                        for idx in range(len(sample1[2])):
+                            motor_watt_average[idx] = (sample1[2][idx] * sample1[3][idx] +
+                                                       sample2[2][idx] * sample2[3][idx]) * 0.5
+                            motor_total_watt_seconds[idx] = motor_watt_average[idx] * sample_duration
+                    except Exception as e:
+                        self.logger.error(e)
+                        self.logger.error(sample1[2])
+                        self.logger.error(sample1[3])
+                    watt_average += sample2[1]
+                    watt_seconds = sample_avg_watts * sample_duration
+                    total_watt_seconds += watt_seconds
+                    distance_sum += sample_distance
+                    last_sample_gps = sample2[0]
+
+                avg_watts = (watt_average) / \
+                    len(self.power_consumption_list)
+                list_subsamples.append(last_sample_gps)
+
+                self.last_energy_segment = EnergySegment(
+                    self.loop_count, oldest_power_sample_gps,
+                    last_sample_gps, distance_sum, total_watt_seconds,
+                    avg_watts, motor_total_watt_seconds,
+                    motor_watt_average, list_subsamples,
+                    self.activate_autonomy,
+                    self.robot_object.wifi_ap_name,
+                    self.robot_object.wifi_strength)
+
+                # Reset power consumption list.
+                self.power_consumption_list = []
+                self.logger.info(f"Avg watts {self.last_energy_segment.avg_watts:.1f}, "
+                                 f"watt seconds per meter: {self.last_energy_segment.watt_seconds_per_meter:.1f}, "
+                                 f"meters per second: {self.last_energy_segment.meters_per_second:.2f}, "
+                                 f"height change {self.last_energy_segment.height_change:.2f}")
+        return time10
+
+    def gps_path_angular_error_rate(self):
+        if len(self.gps_angle_error_rate_averaging_list) == 0:
+            return 0
+        return sum(self.gps_angle_error_rate_averaging_list) / len(self.gps_angle_error_rate_averaging_list)
+
+    def gps_path_lateral_error_rate(self):
+        if len(self.gps_lateral_error_rate_averaging_list) == 0:
+            return 0
+        return sum(self.gps_lateral_error_rate_averaging_list) / len(self.gps_lateral_error_rate_averaging_list)
+
+
+def run_control(remote_to_main_lock,
+                main_to_remote_lock,
+                remote_to_main_string,
+                main_to_remote_string,
+                logging,
+                logging_details,
+                simulated_hardware=False):
+    remote_control = RemoteControl(remote_to_main_lock, main_to_remote_lock,
+                                   remote_to_main_string,
+                                   main_to_remote_string, logging,
+                                   logging_details, simulated_hardware)
     remote_control.run_setup()
     remote_control.run_loop()
 

--- a/vehicle/rtk_process.py
+++ b/vehicle/rtk_process.py
@@ -364,20 +364,18 @@ def rtk_loop_once(tcp_sock1, tcp_sock2, buffers, print_gps=False,
     # if return_simulated_data:
     #     return simulated_data(logger, print_gps)
 
-    print_gps_counter = 0
     errors = 0
     # print(buffers)
     blocking_exception = None
     while True:
         try:
-            start_time = time.time()
             data0 = tcp_sock1.recv(TCP_BUFFER_SIZE).decode('utf-8')
             data1 = tcp_sock2.recv(TCP_BUFFER_SIZE).decode('utf-8')
             buffers[0] += data0
             buffers[1] += data1
             buffers[0], data1 = digest_data(buffers[0], logger)
             buffers[1], data2 = digest_data(buffers[1], logger)
-            #print("Read GPS duration {}".format(time.time() - start_time))
+            # print("Read GPS duration {}".format(time.time() - start_time))
             break
         except BlockingIOError as e:
             blocking_exception = e

--- a/vehicle/spline_lib.py
+++ b/vehicle/spline_lib.py
@@ -22,13 +22,9 @@ limitations under the License.
 """
 
 import numpy as np
-import matplotlib.pyplot as pp
-import mpl_toolkits.mplot3d as mp
 import scipy.interpolate as si
-import scipy.optimize as so
 import scipy.spatial.distance as ssd
 import scipy.integrate
-import functools
 import math
 import gps_tools
 from csaps import csaps
@@ -197,11 +193,11 @@ class GpsSpline():
 
     # Return the distance from u to v along the spline
     def distAlong(self, u, v):
-        return scipy.integrate.quad(slopeMag, u, v)[0]
+        return scipy.integrate.quad(self.slopeMag, u, v)[0]
 
     # Return the distance from u along the spline to the halfway point
     def distAlongToHalf(self, u):
-        return abs(distAlong(0.0, u) - (distAlong(0.0, 1.0)/2))
+        return abs(self.distAlong(0.0, u) - (self.distAlong(0.0, 1.0)/2))
 
     def coordAtU(self, u):
         coord = si.splev(u, self.tck)
@@ -228,8 +224,7 @@ class GpsSpline():
             p = self.points[idx]
             # Using naive x-y distance calculation as it was found to be ~100x
             # faster than gps distance calc.
-            dist = math.sqrt(math.pow(p.lat - point.lat, 2) +
-                             math.pow(p.lon - point.lon, 2))
+            dist = math.sqrt(math.pow(p.lat - point.lat, 2) + math.pow(p.lon - point.lon, 2))
             if dist < min_distance:
                 min_dist_index = idx
                 min_distance = dist
@@ -257,8 +252,7 @@ class GpsSpline():
             p = self.points[idx]
             # Using naive x-y distance calculation as it was found to be ~100x
             # faster than gps distance calc.
-            dist = math.sqrt(math.pow(p.lat - point.lat, 2) +
-                             math.pow(p.lon - point.lon, 2))
+            dist = math.sqrt(math.pow(p.lat - point.lat, 2) + math.pow(p.lon - point.lon, 2))
             if dist < min_distance:
                 min_dist_index = idx
                 min_distance = dist

--- a/vehicle/steering.py
+++ b/vehicle/steering.py
@@ -50,6 +50,8 @@ def steering_to_numpy(calculated_values):
 
 def calculate_steering(steer, throttle, strafe, angle_limit_deg):
     """
+    Returns the steering and velocity of all 4 wheels given the required motion of the vehicle.
+
     Math given from the following page:
     https://www.chiefdelphi.com/t/paper-4-wheel-independent-drive-independent-steering-swerve/107383
     Specifically in the documents:
@@ -98,7 +100,10 @@ def calculate_steering(steer, throttle, strafe, angle_limit_deg):
     vel_right_rear = ws4
     vel_left_rear = ws3
 
-    return {"front_left": (front_left_steering, vel_left_front), "front_right": (front_right_steering, vel_right_front), "rear_left": (rear_left_steering, vel_left_rear), "rear_right": (rear_right_steering, vel_right_rear)}
+    return {"front_left": (front_left_steering, vel_left_front),
+            "front_right": (front_right_steering, vel_right_front),
+            "rear_left": (rear_left_steering, vel_left_rear),
+            "rear_right": (rear_right_steering, vel_right_rear)}
 
 
 def compare_steering_values(old_val, new_val, steering_limit=1.0, velocity_limit=0.5):

--- a/vehicle/utils.py
+++ b/vehicle/utils.py
@@ -1,0 +1,9 @@
+def AppendFIFO(list, value, max_values):
+    list.append(value)
+    while len(list) > max_values:
+        list.pop(0)
+    return list
+
+def clamp(v, low, high):
+    """clamp v to the range of [low, high]"""
+    return max(low, min(v, high))


### PR DESCRIPTION
It replaces https://github.com/Twisted-Fields/acorn-precision-farming-rover/pull/3 for better code diff.

It breaks the main loops of `remote_control_process.py` (nearly 1000 lines of code!) and `master_process.py` into more manageable methods each within 100 lines. Shorter methods are easier to reason about and have proper level of abstraction.

To make sure I didn't break things, I ran the new and old code side by side, and didn't see difference on the behaviour, except a few bugs of the old code which have been fixed in this PR. I wasn't able to make acorn really move in the simulation with this PR, due to a problem exists in the old code too(`travel_speed` is always 0), but after hardcoding the default nav parameter `travel_speed`, the simulated Acorn could rover could follow any path back and forth. Some bugs may be revealed only when running on real hardware, though I'd be surprised if there are many.